### PR TITLE
Add REST grid refresh action for CRUD forms 

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -16,6 +16,7 @@
               :on-update-item="onUpdateItem"
               :on-delete-item="onDeleteItem"
               :items="selectedItems"
+              :refresh="refresh"
               class="d-flex"
             />
           </template>
@@ -24,6 +25,7 @@
             :content="content"
             :view-name="viewName"
             :on-new-item-save="onNewItemSave"
+            :refresh="refresh"
           />
         </div>
         <div v-if="hideFilter">

--- a/config/common/templates/grid/actions/grid/index.vue
+++ b/config/common/templates/grid/actions/grid/index.vue
@@ -5,6 +5,7 @@
       :content="content"
       :view-name="viewName"
       :on-new-item-save="onNewItemSave"
+      :refresh="refresh"
     />
   </div>
 </template>
@@ -13,7 +14,7 @@ import { templateLoaderMixin } from '~/utility'
 
 export default {
   mixins: [templateLoaderMixin],
-  props: ['content', 'viewName', 'onNewItemSave'],
+  props: ['content', 'viewName', 'onNewItemSave', 'refresh'],
   data() {
     return {
       newItem: null,

--- a/config/common/templates/grid/actions/row-select/index.vue
+++ b/config/common/templates/grid/actions/row-select/index.vue
@@ -6,6 +6,7 @@
       :view-name="viewName"
       :items="items"
       :on-update-item="onUpdateItem"
+      :refresh="refresh"
     />
     <component
       :is="deleteItem || null"
@@ -13,6 +14,7 @@
       :view-name="viewName"
       :items="items"
       :on-delete-item="onDeleteItem"
+      :refresh="refresh"
     />
   </div>
 </template>
@@ -21,7 +23,14 @@ import { templateLoaderMixin } from '~/utility'
 
 export default {
   mixins: [templateLoaderMixin],
-  props: ['content', 'viewName', 'items', 'onUpdateItem', 'onDeleteItem'],
+  props: [
+    'content',
+    'viewName',
+    'items',
+    'onUpdateItem',
+    'onDeleteItem',
+    'refresh',
+  ],
   data() {
     return {
       editItem: null,


### PR DESCRIPTION
1. add REST grid refresh action which can be used in New Item, edit Item, delete Item custom forms
2. refresh is available on grid & row-select actions forms. 
