### PR TITLE
Bug 18 banner issue

### DIFF
--- a/config/templates/grids/allEvents-grid/actions/row-select/edit-item.vue
+++ b/config/templates/grids/allEvents-grid/actions/row-select/edit-item.vue
@@ -106,15 +106,15 @@
               </v-row>
             </v-form>
             <v-col cols="12" md="6" sm="6" class="pb-0">
-                  <v-select
-                    v-model="status"
-                    :items="statusDropdown"
-                    :label="$t('Common.Status')"
-                    outlined
-                    persistent-hint
-                    dense
-                  ></v-select>
-                </v-col>
+              <v-select
+                v-model="status"
+                :items="statusDropdown"
+                :label="$t('Common.Status')"
+                outlined
+                persistent-hint
+                dense
+              ></v-select>
+            </v-col>
             <v-col cols="12" md="6" sm="6" class="pb-0">
               <v-text-field
                 v-model="formData.Organizer"
@@ -671,8 +671,10 @@ export default {
       this.formData.Status = this.status
       this.formData.Privacy = this.privacy
       this.formData.Currency = this.currency
-      if (this.formData.Images.length === 0) {
+      if (this.selectedImage !== '') {
         this.formData.Images.push(this.selectedImage)
+      } else {
+        this.formData.Images = []
       }
       if (
         this.formData.BusinessType !== 'Recurring' ||
@@ -764,7 +766,11 @@ export default {
       }
     },
     fileUploadedEventBanner(data) {
-      this.selectedImage = data[0]
+      if (data.length > 0) {
+        this.selectedImage = data[0]
+      } else {
+        this.selectedImage = ''
+      }
     },
   },
   apollo: {

--- a/config/templates/grids/allEvents-grid/actions/row-select/edit-item.vue
+++ b/config/templates/grids/allEvents-grid/actions/row-select/edit-item.vue
@@ -375,7 +375,7 @@
               </div>
               <File
                 :field="fileField"
-                :value="formData.Images"
+                :value="selectedImage"
                 @input="fileUploadedEventBanner"
               />
             </v-col>
@@ -671,7 +671,8 @@ export default {
       this.formData.Status = this.status
       this.formData.Privacy = this.privacy
       this.formData.Currency = this.currency
-      if (this.selectedImage !== '') {
+      if (this.selectedImage !== '' || this.formData.Images.length === 0) {
+        this.formData.Images = []
         this.formData.Images.push(this.selectedImage)
       } else {
         this.formData.Images = []
@@ -796,6 +797,7 @@ export default {
         }
       },
       update(data) {
+        debugger
         const event = formatGQLResult(data, 'Event')
         this.formData = event.length > 0 ? { ...event[0] } : {}
         this.formData.id = this.$route.params.id
@@ -803,6 +805,7 @@ export default {
         this.status = this.formData.Status
         this.privacy = this.formData.Privacy
         this.currency = this.formData.Currency
+        this.selectedImage = this.formData.Images
         if (
           this.formData.BusinessType !== 'Recurring' &&
           this.formData.StartDate !== null &&

--- a/config/templates/grids/allEvents-grid/actions/row-select/edit-item.vue
+++ b/config/templates/grids/allEvents-grid/actions/row-select/edit-item.vue
@@ -797,7 +797,6 @@ export default {
         }
       },
       update(data) {
-        debugger
         const event = formatGQLResult(data, 'Event')
         this.formData = event.length > 0 ? { ...event[0] } : {}
         this.formData.id = this.$route.params.id

--- a/config/templates/grids/livedraft-grid/body.vue
+++ b/config/templates/grids/livedraft-grid/body.vue
@@ -149,7 +149,7 @@
                     <v-list-item
                       v-if="item.Status === 'Not ready'"
                       :key="item.id"
-                      @click="stop"
+                      @click="deleteEvent(item.id)"
                     >
                       <v-list-item-icon class="mr-2">
                         <i class="fa fa-trash mt-1" aria-hidden="true"></i>
@@ -341,7 +341,7 @@
       </v-row>
     </div>
     <div v-if="eventForm">
-      <editEventForm :id="id" :event-form.sync="eventForm" />
+      <editEventForm :id="id" :event-form.sync="eventForm" :refresh="refresh" />
     </div>
     <makeCopy :id="id" :key="count" :is-make-copy.sync="isMakeCopy" />
     <v-snackbar v-model="snackbar" :timeout="timeout" :top="true">
@@ -364,6 +364,11 @@ export default {
   props: {
     items: { type: Array, default: () => [] },
     offset: { type: Boolean, default: false },
+    refresh: {
+      type: Function,
+      default: () => false,
+      required: false,
+    },
   },
   data() {
     return {
@@ -395,7 +400,9 @@ export default {
         if (check === true) {
           const res = await this.$axios.$delete(`${url}Events/${id}`)
           if (res) {
-            this.snackbarText = this.$t('Messages.Success.DeletedSuccessfully')
+            this.snackbarText = this.$t(
+              'Messages.Success.EventDeletedSuccessfully'
+            )
             this.snackbar = true
             this.$eventBus.$emit('grid-refresh')
           }

--- a/config/templates/grids/registrationAttendees-grid/column-checkin.vue
+++ b/config/templates/grids/registrationAttendees-grid/column-checkin.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="positionRelative position">
-    <div v-if="item.CheckIn === null" class="pt-1" style="height: 10px;">
+    <div
+      v-if="item.CheckIn === null && item.Status !== 'Failed'"
+      class="pt-1"
+      style="height: 10px;"
+    >
       <v-chip
         class="ma-2 pb-0 mt-1"
         height="13"
@@ -13,7 +17,11 @@
         <i18n path="Common.CheckIn" />
       </v-chip>
     </div>
-    <div v-else style="display: flex; height: 13px;" class="ma-2 pb-0 mt-1">
+    <div
+      v-if="item.CheckIn !== null && item.Status !== 'Failed'"
+      style="display: flex; height: 13px;"
+      class="ma-2 pb-0 mt-1"
+    >
       <v-icon color="success" class="pr-1 fs-14">mdi-check</v-icon>
       <i18n path="Common.CheckedInJustnow" class="pr-1" />
       <timeAgo :date="item.CheckIn" />

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -843,6 +843,7 @@
       "FailedDeleteComment": "Failed to delete comment.",
       "AccessKeySecretCopied": "Access Key and Secret copied to clipboard",
       "DeletedSuccessfully": "Item deleted successfully",
+      "EventDeletedSuccessfully": "Event deleted successfully",
       "SuccessfulCheckedIn": "Congratulations, You have successfully checked in.",
       "ConnectionSuccessfully": "Connection Updated Successfully",
       "ConnectionDeletedSuccessfully": "Connection deleted Successfully",

--- a/pages/apps/_app/event/_id/editEventForm.vue
+++ b/pages/apps/_app/event/_id/editEventForm.vue
@@ -278,6 +278,11 @@ export default {
       type: String,
       default: '',
     },
+    refresh: {
+      type: Function,
+      default: () => false,
+      required: false,
+    },
   },
   data() {
     return {
@@ -442,7 +447,7 @@ export default {
       this.$emit('update:eventForm', false)
       this.onReset()
     },
-    refresh() {
+    refreshGrid() {
       this.$refs.form.$parent.$parent.refresh()
       this.$apollo.queries.data.refresh()
     },
@@ -509,6 +514,7 @@ export default {
           )
           if (res) {
             this.close()
+            this.refreshGrid()
             this.refresh()
             this.data.event = res
           }
@@ -531,6 +537,7 @@ export default {
             }
           )
           if (res) {
+            debugger
             this.close()
             this.refresh()
             return (this.data.event = res)

--- a/pages/apps/_app/event/_id/editEventForm.vue
+++ b/pages/apps/_app/event/_id/editEventForm.vue
@@ -537,7 +537,6 @@ export default {
             }
           )
           if (res) {
-            debugger
             this.close()
             this.refresh()
             return (this.data.event = res)

--- a/pages/apps/_app/event/recurring/_id/index.vue
+++ b/pages/apps/_app/event/recurring/_id/index.vue
@@ -1163,6 +1163,7 @@
         <editSiteSetting :site-setting.sync="siteSetting" />
       </div>
       <makeCopy :is-make-copy.sync="isMakeCopy" />
+      <confirm ref="confirm"></confirm>
     </v-flex>
   </div>
 </template>
@@ -1463,7 +1464,11 @@ export default {
     },
     async deleteBannerFile(e, id) {
       const url = this.$bitpod.getApiUrl()
-      const checkRes = await this.$confirm('Are you sure you want to delete?')
+      const checkRes = await this.$refs.confirm.open(
+        this.$t('Drawer.Delete'),
+        this.$t('Messages.Warn.DeleteImage'),
+        { color: 'error lighten-1' }
+      )
       if (checkRes) {
         const res = await this.$axios.delete(
           `${url}Events/${this.$route.params.id}/BannerImage/${id}`
@@ -1479,7 +1484,11 @@ export default {
     },
     async deleteLogoFile(id) {
       const url = this.$bitpod.getApiUrl()
-      const checkRes = await this.$confirm('Are you sure you want to delete?')
+      const checkRes = await this.$refs.confirm.open(
+        this.$t('Drawer.Delete'),
+        this.$t('Messages.Warn.DeleteImage'),
+        { color: 'error lighten-1' }
+      )
       if (checkRes) {
         const res = await this.$axios.delete(
           `${url}Events/${this.$route.params.id}/LogoURL/${id}`
@@ -1495,7 +1504,11 @@ export default {
     },
     async deleteOtherFile(id) {
       const url = this.$bitpod.getApiUrl()
-      const checkRes = await this.$confirm('Are you sure you want to delete?')
+      const checkRes = await this.$refs.confirm.open(
+        this.$t('Drawer.Delete'),
+        this.$t('Messages.Warn.DeleteImage'),
+        { color: 'error lighten-1' }
+      )
       if (checkRes) {
         const res = await this.$axios.delete(
           `${url}Events/${this.$route.params.id}/Others/${id}`

--- a/pages/apps/_app/registration/_id/index.vue
+++ b/pages/apps/_app/registration/_id/index.vue
@@ -34,9 +34,20 @@
                           {{ data.registration.FirstName }}
                         </h2>
                       </v-list-item-title>
-                      <v-list-item-subtitle>{{
-                        data.registration.Status
-                      }}</v-list-item-subtitle>
+                      <v-list-item-subtitle>
+                        <v-chip
+                          small
+                          :class="{
+                            blue: data.registration.Status === 'Cancelled',
+                            red: data.registration.Status === 'Failed',
+                            orange: data.registration.Status === 'Pending',
+                            success: data.registration.Status === 'Success',
+                          }"
+                          text-color="white"
+                        >
+                          {{ data.registration.Status }}</v-chip
+                        ></v-list-item-subtitle
+                      >
                     </v-list-item-content>
                   </v-list-item>
                 </v-list>


### PR DESCRIPTION
Fixed:
+676:if we delete any draft event confirmation message should be " Event deleted Successfully "
+added delete recurring draft event functionality from the tiles
+672:when we edit the event name from tile edit option then not reflect the changes on tile until we refresh the page 
+669:In registration detail view added the chip to the status of registration
+663:For some events getting two banner image image attached to it
+622:remove check in option for failed registration from the registration attendee grid
