### PR TITLE
fix text overflow due to file name len org gallery (711)

### DIFF
--- a/pages/apps/_app/organization/_id/index.vue
+++ b/pages/apps/_app/organization/_id/index.vue
@@ -206,7 +206,7 @@
             <v-flex class="mt-1 d-flex">
               <v-card-text class="pa-0 pb-1">
                 <a
-                  class="d-inline-block text-truncate anchorTag"
+                  class="d-inline-block text-truncate anchorTag file-name"
                   :href="getAttachmentLink(image, true)"
                   >{{
                     OtherImageName[index] && OtherImageName[index].fileName
@@ -738,5 +738,8 @@ export default {
 }
 .otherImg {
   visibility: hidden;
+}
+.file-name {
+  width: 125px;
 }
 </style>


### PR DESCRIPTION
- limits width of text element to 125px in image gallery to prevent irregular sizing of image cards and bring `.text-truncate` into effect.