### PR TITLE
fix autocomplete dropdown not attaching 434

### DIFF
--- a/components/common/form/timezone/index.vue
+++ b/components/common/form/timezone/index.vue
@@ -7,6 +7,7 @@
     :loading="isLoading"
     :label="$t(field.caption)"
     :rules="rules"
+    :attach="attach"
     dense
     outlined
     @change="onChange"
@@ -38,6 +39,10 @@ export default {
     rules: {
       type: Array,
       default: () => [],
+    },
+    attach: {
+      type: [String, Boolean],
+      default: false,
     },
   },
   data() {

--- a/components/newRecurringEvent.vue
+++ b/components/newRecurringEvent.vue
@@ -808,6 +808,13 @@
                             />
                           </td>
                           <td class="pa-2 pb-0 st-date e-td" data-title="">
+                            <div class="positionAbsolute">
+                              <div
+                                class="autocomplete-dropdown positionRelative"
+                              >
+                                <div :id="`duration-select-${k}`"></div>
+                              </div>
+                            </div>
                             <v-autocomplete
                               v-model="session.Duration"
                               :items="slotLookupOptions"
@@ -815,6 +822,7 @@
                               item-value="key"
                               outlined
                               dense
+                              :attach="`#duration-select-${k}`"
                               @change="changeDuration(k)"
                             ></v-autocomplete>
                           </td>

--- a/components/newRecurringEvent.vue
+++ b/components/newRecurringEvent.vue
@@ -819,13 +819,21 @@
                             ></v-autocomplete>
                           </td>
                           <td
-                            class="pa-2 pb-0 event-timezone text-truncate e-td"
+                            class="pa-2 pb-0 event-timezone e-td"
                             data-title=""
                           >
+                            <div class="positionAbsolute">
+                              <div
+                                class="autocomplete-dropdown positionRelative"
+                              >
+                                <div :id="`timezone-select-${k}`"></div>
+                              </div>
+                            </div>
                             <Timezone
                               v-model="session.Timezone"
                               :rules="[rules.required]"
                               :field="timezonefield"
+                              :attach="`#timezone-select-${k}`"
                             ></Timezone>
                           </td>
 
@@ -2407,5 +2415,8 @@ export default {
 }
 .event-inner {
   min-height: 410px;
+}
+.autocomplete-dropdown {
+  margin-top: 13px;
 }
 </style>


### PR DESCRIPTION
This is a partial fix and will require the following fixes:
`Issue present on tablet resolution when scrolling horizontally.`

Possible fix that comes to mind:
- Disable scrolling of content when pop-up is open.