### PR TITLE
limit overflow-y hidden to mobile resolution

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -748,8 +748,8 @@ export default {
   .grid-actions-spread {
     display: none !important;
   }
-}
-.v-menu__content {
-  overflow-y: hidden;
+  div[role='menu'].v-menu__content {
+    overflow-y: hidden;
+  }
 }
 </style>


### PR DESCRIPTION
This is a patch to the fix applied in #213.

limit overflow-y hidden to mobile resolution:
- only apply when div has role of menu