### PR TITLE
bug_26:badge toaster get triggered on closing the form

### DIFF
--- a/pages/apps/_app/event/_id/newBadgeForm.vue
+++ b/pages/apps/_app/event/_id/newBadgeForm.vue
@@ -297,7 +297,6 @@ export default {
       this.tabs = 'tab-1'
       this.RTEValue = ''
       this.$emit('update:newBadge', false)
-      this.$emit('update:snackbar', true)
     },
     refresh() {
       this.$apollo.queries.data1.refresh()


### PR DESCRIPTION
Fixed:
+856:when we close create new badge form then also shows success message as event updated successfully



