### PR TITLE
force data table rerender on body slot

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -140,6 +140,7 @@
         <v-data-table
           v-model="selectedItems"
           dense
+          :key="componentRerenderKey"
           :headers="translate(headers)"
           :items="tableData.items"
           :single-select="singleSelect"
@@ -534,6 +535,7 @@ export default {
       footerObserver: null,
       winWidth: window.innerWidth,
       itemPerPage: 0,
+      componentRerenderKey: 0,
     }
   },
   computed: {
@@ -611,6 +613,7 @@ export default {
         [`templates/grids/${this.templateFolderName}/${slot}.vue`],
         false
       )
+      this.componentRerenderKey += this.slotTemplates.body ? 1 : 0
     })
     const templateName = this.templateFolderName
     ACTION_TYPES.forEach(async (actionType) => {


### PR DESCRIPTION
- adds a `key` to the `v-data-table`.
- When the `key` value gets updated, it indicates to Vue that it should re-render the component.
- The component should be rendered with the correct slot.