### PR TITLE
Fixed issue of invitee survey template

### DIFF
--- a/components/newRecurringEvent.vue
+++ b/components/newRecurringEvent.vue
@@ -609,6 +609,8 @@
                       required
                       :error-messages="uniqueLinkValidationMsg"
                       @keyup="changeUniqueLink($event)"
+                      @input="changeUniqueLink($event)"
+                      @change="changeUniqueLink($event)"
                     ></v-text-field>
                   </v-col>
                 </v-row>
@@ -1016,7 +1018,10 @@
           ><i18n path="Drawer.Next"
         /></v-btn>
         <SaveBtn
-          v-if="currentTab > 2 && !isEventCreate && !isEventPublish"
+          v-if="
+            (currentTab > 2 && !isEventCreate && !isEventPublish) ||
+            isInalidEventLink
+          "
           color="primary"
           :disabled="isSaveButtonDisabled"
           depressed
@@ -2337,7 +2342,7 @@ export default {
       value = value.toLowerCase().replace(/\s/g, '')
       value = value.trim()
       this.eventData.UniqLink = value
-      const regex = RegExp(/^(?![0-9]*$)[a-zA-Z0-9]+$/)
+      const regex = RegExp(/^(?![0-9]*$){1,}[a-zA-Z0-9]+$/)
       if (regex.test(value)) {
         if (isNaN(value)) {
           this.eventData.UniqLink = value

--- a/components/newSingleEvent.vue
+++ b/components/newSingleEvent.vue
@@ -118,7 +118,8 @@
                     dense
                     required
                     :error-messages="uniqueLinkValidationMsg"
-                    @keyup="changeUniqueLink($event)"
+                    @input="changeUniqueLink($event)"
+                    @change="changeUniqueLink($event)"
                   ></v-text-field>
                 </v-col>
               </v-row>
@@ -522,7 +523,9 @@
         <SaveBtn
           v-if="currentTab > 2 && !isEventCreate && !isEventPublish"
           color="primary"
-          :disabled="isSaveButtonDisabled || !valid || !datevalid"
+          :disabled="
+            isSaveButtonDisabled || !valid || !datevalid || isInvalidEventLink
+          "
           depressed
           :action="saveRecord"
           class="ml-2"
@@ -1312,13 +1315,14 @@ export default {
     verifyUniqueLink(value) {
       value = value.toLowerCase().replace(/\s/g, '')
       value = value.trim()
-      const regex = RegExp(/^(?![0-9]*$)[a-zA-Z0-9]+$/)
+      const regex = RegExp(/^(?![0-9]*$){1,}[a-zA-Z0-9]+$/)
       if (regex.test(value)) {
         if (isNaN(value)) {
           this.eventData.UniqLink = value
           this.checkUniqueLink(this.eventData.UniqLink)
         }
       } else {
+        this.isUniqLinkValid = false
         this.isInvalidEventLink = true
         this.uniqueLinkMessage = this.$t('Messages.Warn.UniqueLinkFormat')
       }

--- a/config/templates/grids/eventInvites-grid/actions/grid/sendEventInvite.vue
+++ b/config/templates/grids/eventInvites-grid/actions/grid/sendEventInvite.vue
@@ -760,14 +760,14 @@
               v-if="curentTab > 0"
               depressed
               :disabled="acknowledgement"
-              @click="curentTab--"
+              @click="onPrev"
               ><i18n path="Drawer.Prev"
             /></v-btn>
             <v-btn
               v-if="curentTab < 3"
               color="primary"
               depressed
-              @click="curentTab++"
+              @click="onNext"
               ><i18n path="Drawer.Next"
             /></v-btn>
           </v-card-actions>
@@ -990,6 +990,14 @@ export default {
     this.$eventBus.$off('itemSelected')
   },
   methods: {
+    onPrev() {
+      this.curentTab--
+      document.getElementsByClassName('invite-inner')[0].scrollTop = 0
+    },
+    onNext() {
+      this.curentTab++
+      document.getElementsByClassName('invite-inner')[0].scrollTop = 0
+    },
     updateSelectedList(data) {
       if (data.viewName === 'Contacts') {
         this.selectedList = [...data.items]

--- a/config/templates/grids/eventRegistrationForm-grid/actions/row-select/edit-item.vue
+++ b/config/templates/grids/eventRegistrationForm-grid/actions/row-select/edit-item.vue
@@ -19,7 +19,7 @@
         <v-card-title
           class="pl-md-10 pl-lg-10 pl-xl-15 pr-1 pb-0 pt-1 d-flex align-start"
         >
-          <h2 class="black--text pt-10 pb-9 font-weight-regular">
+          <h2 class="black--text pt-5 pb-4 font-weight-regular text-h5">
             <i18n path="Common.EditRegistrationForm" />
           </h2>
           <v-spacer></v-spacer>
@@ -147,7 +147,7 @@ export default {
   watch: {
     snackbar(newVal) {
       if (!newVal) {
-        this.$parent.refresh()
+        this.refresh()
       }
     },
   },
@@ -200,7 +200,9 @@ export default {
         )
         if (res) {
           this.dialog = false
-          this.snackbarText = this.$t('Messages.Success.RecordUpdatedSuccess')
+          this.snackbarText = this.$t(
+            'Messages.Success.RegistrationFormUpdatedSuccess'
+          )
           this.snackbar = true
         }
       } catch (e) {

--- a/config/templates/grids/eventRegistrationType-grid/column-isdefault.vue
+++ b/config/templates/grids/eventRegistrationType-grid/column-isdefault.vue
@@ -25,9 +25,6 @@
 </template>
 
 <script>
-import gql from 'graphql-tag'
-import registrationType from '~/config/apps/event/gql/registrationType.gql'
-import { formatGQLResult } from '~/utility/gql.js'
 export default {
   props: {
     item: {

--- a/config/templates/grids/eventSession-grid/actions/form.vue
+++ b/config/templates/grids/eventSession-grid/actions/form.vue
@@ -688,9 +688,9 @@ export default {
       }
       if (res) {
         if (this.isEdit) {
-          this.snackbarText = this.$t('Messages.Success.RecordUpdatedSuccess')
+          this.snackbarText = this.$t('Messages.Success.SessionUpdatedSuccess')
         } else {
-          this.snackbarText = this.$t('Messages.Success.RecordCreateSuccess')
+          this.snackbarText = this.$t('Messages.Success.SessionCreatedSuccess')
         }
         this.snackbar = true
         this.closeForm()

--- a/config/templates/grids/eventTask-grid/edit-surveytemplate.vue
+++ b/config/templates/grids/eventTask-grid/edit-surveytemplate.vue
@@ -237,6 +237,8 @@ export default {
       if (this.template === 'General Template') {
         this.selectedList = this.$parent.$parent.$data.selectedItems
       }
+      this.$apollo.queries.MarketingTemplate.refresh()
+      this.$apollo.queries.editTemplate.refresh()
     },
     resetForm() {
       this.dialog = false

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -949,7 +949,10 @@
       "QuestionRecordCreatedSuccess":"Question created successfully",
       "QuestionRecordUpdatedSuccess":"Question updated successfully",
       "TicketRecordCreatedSuccess":"Ticket created successfully",
-      "TicketRecordUpdatedSuccess":"Ticket updated successfully"
+      "TicketRecordUpdatedSuccess":"Ticket updated successfully",
+      "RegistrationFormUpdatedSuccess":"Registration Form updated successfully",
+      "SessionCreatedSuccess":"Session created successfully",
+      "SessionUpdatedSuccess":"Session updated successfully"
     }
   },
   "$vuetify": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -946,7 +946,10 @@
       "QuestionRecordCreatedSuccess":"Question créée avec succès",
       "QuestionRecordUpdatedSuccess":"Question mise à jour avec succès",
       "TicketRecordCreatedSuccess":"Ticket créé avec succès",
-      "TicketRecordUpdatedSuccess":"Billet mis à jour avec succès"
+      "TicketRecordUpdatedSuccess":"Billet mis à jour avec succès",
+      "RegistrationFormUpdatedSuccess":"Formulaire d'inscription mis à jour avec succès",
+      "SessionCreatedSuccess":"Session créée avec succès",
+      "SessionUpdatedSuccess":"Session mise à jour avec succès"
     }
   },
   "$vuetify": {

--- a/locales/he.json
+++ b/locales/he.json
@@ -948,7 +948,10 @@
       "QuestionRecordCreatedSuccess":"שאלה נוצרה בהצלחה",
       "QuestionRecordUpdatedSuccess":"השאלה עודכנה בהצלחה",
       "TicketRecordCreatedSuccess":"הכרטיס נוצר בהצלחה",
-      "TicketRecordUpdatedSuccess":"הכרטיס עודכן בהצלחה"
+      "TicketRecordUpdatedSuccess":"הכרטיס עודכן בהצלחה",
+      "RegistrationFormUpdatedSuccess":"טופס ההרשמה עודכן בהצלחה",
+      "SessionCreatedSuccess":"ההפעלה נוצרה בהצלחה",
+      "SessionUpdatedSuccess":"ההפעלה עודכנה בהצלחה"
     }
   },
   "$vuetify": {

--- a/locales/hi-IN.json
+++ b/locales/hi-IN.json
@@ -948,7 +948,10 @@
       "QuestionRecordCreatedSuccess":"प्रश्न सफलतापूर्वक बनाया गया",
       "QuestionRecordUpdatedSuccess":"प्रश्न सफलतापूर्वक अपडेट किया गया",
       "TicketRecordCreatedSuccess":"टिकट सफलतापूर्वक बनाया गया",
-      "TicketRecordUpdatedSuccess":"टिकट सफलतापूर्वक अपडेट किया गया"
+      "TicketRecordUpdatedSuccess":"टिकट सफलतापूर्वक अपडेट किया गया",
+      "RegistrationFormUpdatedSuccess":"पंजीकरण फॉर्म सफलतापूर्वक अपडेट किया गया",
+      "SessionCreatedSuccess":"सत्र सफलतापूर्वक बनाया गया",
+      "SessionUpdatedSuccess":"Session updated successfully"
     }
   },
   "$vuetify": {

--- a/utility/rules.js
+++ b/utility/rules.js
@@ -9,7 +9,8 @@ export function rules(i18n) {
         v
       ) || i18n.t('Messages.Error.EmailRequired'),
     link: (v) =>
-      /^[a-z0-9]+$/i.test(v) || i18n.t('Messages.Warn.UniqueLinkFormat'),
+      /^(?![0-9]*$){1,}[a-zA-Z0-9]+$/i.test(v) ||
+      i18n.t('Messages.Warn.UniqueLinkFormat'),
     onlineEventLink: (v) => {
       return !v
         ? i18n.t('Messages.Error.FieldRequired')


### PR DESCRIPTION
+920:after creating and editing the session message should be like session created /edited successfully
+921:check the edit registration form top space and success message should be like "Registration form updated successfully" Not fixed
+901:Location not getting in calendar invite for bitpod virtual type recurring event 
+905:while sending an email invite from contact scroll should set to top when i change the tab
+868:not getting survey email template while editing template (Random Issues)
+880:while creating an event not getting any error message if user added numeric values in eventname and next button also not get enabled 
+898:While creating event , when there is error message on single event the save button should be disabled like recurring event