### PR TITLE
add more logic to decide events on sale is empty

### DIFF
--- a/pages/apps/_app/eventboard/index.vue
+++ b/pages/apps/_app/eventboard/index.vue
@@ -1025,7 +1025,7 @@ export default {
           })
           this.eventOnSaleLoaded = true
           this.eventOnSaleEmpty = false
-        } else {
+        } else if (!eventData.length && data.Event?.EventCount > 0) {
           this.eventOnSaleEmpty = true
         }
       },


### PR DESCRIPTION
- fixes flash of event is empty message instead of skeleton when the eventboard is loading.