### PR TITLE
add logic to move rowselect to triple dot on desktop 933 62

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :id="viewName">
     <ExportLoader
       :is-loading="exportInProgress"
       :title="$t('Drawer.ExportToCSV')"
@@ -13,6 +13,7 @@
         }
       "
     />
+    <confirm ref="confirm"></confirm>
     <template v-if="!!error">
       <div>
         <component :is="errorTemplate || null" :error="error" />
@@ -39,7 +40,7 @@
             'elevation-1 boxview rounded': onlySticky && winWidth < 600,
           }"
         >
-          <div v-if="showTripleDot" class="grid-actions-menu">
+          <div v-if="showTripleDot && winWidth < 600" class="grid-actions-menu">
             <v-menu right :offset-y="offset" transition="slide-y-transition">
               <template v-slot:activator="{ on, attrs }">
                 <v-btn icon small v-bind="attrs" v-on="on">
@@ -74,22 +75,8 @@
               </v-list>
             </v-menu>
           </div>
-          <div class="grid-actions-spread">
-            <div class="d-flex">
-              <component
-                :is="actionTemplates['row-select'] || null"
-                v-if="selectedItems.length > 0"
-                :content="content"
-                :view-name="viewName"
-                :on-update-item="onUpdateItem"
-                :on-delete-item="onDeleteItem"
-                :items="selectedItems"
-                :refresh="refresh"
-                :context="context"
-                :get-action-items="getActionItems"
-                class="d-inline-flex"
-                @has-custom-row-action="getRowOption"
-              />
+          <div v-else-if="winWidth > 600" class="grid-actions-spread">
+            <div class="d-flex align-center">
               <component
                 :is="actionTemplates['grid'] || null"
                 :content="content"
@@ -102,9 +89,25 @@
                 class="d-inline-flex"
                 @has-custom-grid-action="getGridOption"
               />
+              <component
+                :is="actionTemplates['row-select'] || null"
+                v-if="
+                  selectedItems.length > 0 && actionsCount <= baseActionCount
+                "
+                :content="content"
+                :view-name="viewName"
+                :on-update-item="onUpdateItem"
+                :on-delete-item="onDeleteItem"
+                :items="selectedItems"
+                :refresh="refresh"
+                :context="context"
+                :get-action-items="getActionItems"
+                class="d-inline-flex"
+                @has-custom-row-action="getRowOption"
+              />
             </div>
           </div>
-          <div v-if="hideFilter">
+          <div v-if="hideFilter" class="grid-filter">
             <slot name="filter">
               <FieldsFilter
                 v-model="filters"
@@ -130,6 +133,32 @@
               ></v-text-field>
             </slot>
           </div>
+          <v-menu
+            v-if="selectedItems.length > 0 && actionsCount > baseActionCount"
+            right
+            :offset-y="offset"
+            transition="slide-y-transition"
+          >
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn icon small v-bind="attrs" v-on="on">
+                <v-icon>mdi-dots-vertical</v-icon>
+              </v-btn>
+            </template>
+            <v-list dense>
+              <component
+                :is="actionTemplates['row-select'] || null"
+                :content="content"
+                :view-name="viewName"
+                :on-update-item="onUpdateItem"
+                :on-delete-item="onDeleteItem"
+                :items="selectedItems"
+                :refresh="refresh"
+                :context="context"
+                :get-action-items="getActionItems"
+                @has-custom-row-action="getRowOption"
+              />
+            </v-list>
+          </v-menu>
         </div>
       </div>
       <v-skeleton-loader
@@ -675,6 +704,40 @@ export default {
         this.viewName === this.$store.state.exportInProgress.key
       )
     },
+    actionsCount() {
+      if (this.winWidth > 600) {
+        const actionSpreadParents = document
+          .getElementById(this.viewName)
+          .getElementsByClassName('grid-actions-spread')?.[0]
+          ?.getElementsByClassName('d-flex')?.[0]
+          ?.getElementsByClassName('d-inline-flex')
+        const actionsSpreadCount =
+          [...actionSpreadParents].reduce(
+            (acc, elem) => acc + elem.childElementCount,
+            0
+          ) +
+          (document
+            .getElementById(this.viewName)
+            .getElementsByClassName('grid-filter')?.[0]
+            ? 1
+            : 0) +
+          (document
+            .getElementById(this.viewName)
+            .getElementsByClassName('grid-search-section')?.[0]
+            ? 1
+            : 0)
+        return actionsSpreadCount
+      }
+      return 0
+    },
+    baseActionCount() {
+      if (this.winWidth <= 1600 && this.winWidth >= 600) {
+        return 2
+      } else if (this.winWidth >= 1600) {
+        return 3
+      }
+      return 0
+    },
   },
   watch: {
     filters() {
@@ -696,6 +759,8 @@ export default {
     }, 2000)
     this.$eventBus.$on('unselectAll-record', this.unselectAllRecord)
     this.$eventBus.$on('eventInvites-grid-refresh', this.refreshGrid)
+    this.$eventBus.$on('toggle-snackbar', this.toggleSnackbar)
+    this.$eventBus.$on('toggle-confirm', this.toggleConfirm)
     if (this.loadRestData) {
       this.$eventBus.$on('user-created', this.loadRestData)
     }
@@ -733,12 +798,10 @@ export default {
         return el.parentElement.appendChild(sentinel)
       })
     }
-
     const fireEvent = (stuck, target) => {
       const e = new CustomEvent('sticky-change', { detail: { stuck, target } })
       document.dispatchEvent(e)
     }
-
     const observeHeaders = (container) => {
       this.headerObserver = new IntersectionObserver(
         (records, observer) => {
@@ -770,7 +833,6 @@ export default {
       const sentinels = addSentinels(container, 'sticky_sentinel--top')
       sentinels.forEach((el) => this.headerObserver.observe(el))
     }
-
     const observeFooters = (container) => {
       this.footerObserver = new IntersectionObserver(
         (records, observer) => {
@@ -803,14 +865,12 @@ export default {
       const sentinels = addSentinels(container, 'sticky_sentinel--bottom')
       sentinels.forEach((el) => this.footerObserver.observe(el))
     }
-
     const observeStickyHeaderChanges = (container) => {
       observeHeaders(container)
       observeFooters(container)
     }
-
-    observeStickyHeaderChanges(document.querySelector('#inspire'))
-
+    if (this.winWidth < 600)
+      observeStickyHeaderChanges(document.querySelector(`#${this.viewName}`))
     this.$nextTick(() => {
       window.addEventListener('resize', this.onResize)
     })
@@ -827,11 +887,36 @@ export default {
     this.$eventBus.$off('user-created')
     this.$eventBus.$off('grids-refresh')
     this.$eventBus.$off('unselectAll-record')
-    this.headerObserver.disconnect()
-    this.footerObserver.disconnect()
+    this.$eventBus.$off('toggle-snackbar')
+    this.$eventBus.$off('toggle-confirm')
+    this.headerObserver?.disconnect()
+    this.footerObserver?.disconnect()
     window.removeEventListener('resize', this.onResize)
   },
   methods: {
+    toggleSnackbar(toggleViewName, message, timeout = 3000) {
+      if (this.viewName === toggleViewName) {
+        this.snackbarText = message
+        this.timeout = timeout
+        this.snackbar = true
+      }
+    },
+    async toggleConfirm(
+      toggleViewName,
+      callbackEvent,
+      { title, message, options }
+    ) {
+      if (this.viewName === toggleViewName) {
+        const confirmResend = await this.$refs.confirm.open(
+          title,
+          message,
+          options
+        )
+        if (confirmResend) {
+          this.$eventBus.$emit(`${callbackEvent}`)
+        }
+      }
+    },
     refreshGrid(viewName) {
       if (viewName === this.viewName) {
         this.refresh()
@@ -1099,6 +1184,7 @@ export default {
         try {
           this.tableData = await getDataFunc.call(this, options)
           this.noDataText = this.$t('Common.NoDataAvailable')
+          this.componentRerenderKey += this.slotTemplates.body ? 1 : 0
           this.loading = false
         } catch (e) {
           console.error(
@@ -1163,6 +1249,7 @@ export default {
               }
             : {}
         if (Object.keys(data).length > 0) this.error = ''
+        this.componentRerenderKey += this.slotTemplates.body ? 1 : 0
         return tableData
       },
       result({ data, loading, networkStatus }) {

--- a/config/templates/grids/eventRegistrations-grid/actions/row-select/index.vue
+++ b/config/templates/grids/eventRegistrations-grid/actions/row-select/index.vue
@@ -21,7 +21,7 @@
       />
     </v-list-item>
     <v-list-item>
-      <resendRegistrationEmail :items="items" />
+      <resendRegistrationEmail :items="items" :view-name="viewName" />
     </v-list-item>
   </div>
 </template>

--- a/pages/apps/_app/event/_id/index.vue
+++ b/pages/apps/_app/event/_id/index.vue
@@ -1780,7 +1780,9 @@ export default {
       try {
         const url = this.$bitpod.getApiUrl()
         const res = await this.$axios.get(
-          `${url}Events/${this.$route && this.$route.params && this.$route.params.id}/Attende`
+          `${url}Events/${
+            this.$route && this.$route.params && this.$route.params.id
+          }/Attende`
         )
         if (res) {
           this.attendees = res.data
@@ -1788,7 +1790,9 @@ export default {
         }
       } catch (e) {
         console.error(
-          `Error in apps/event/_id/index.vue while making a GQL call to Attendee model in method getAttendees context: EventId:-${this.$route && this.$route.params && this.$route.params.id}`,
+          `Error in apps/event/_id/index.vue while making a GQL call to Attendee model in method getAttendees context: EventId:-${
+            this.$route && this.$route.params && this.$route.params.id
+          }`,
           e
         )
       }


### PR DESCRIPTION
This PR also adds the following functionality:
- The `confirm` dialog has been moved to the  `common/grid` component. In order to use the component, the event `toggle-confirm` needs to be called:
  - It requires the following parameters to be passed with it:
    - `this.viewName | String` - name of the view for which it toggles
    - `callback | String` - name of event to emit on successful confirmation
    - `options | Object` - standard options for the confirm dialog, contains a `title | String` value, `message | String` value and `options | Object`. Ref. to `components/Confirm.vue`.
-  The `snackbar` component has also had functionality added to be toggled via eventbus in the `common/grid`, the event is `toggle-snackbar`.
   - It requires the following parameters to be passed with it:
     - `this.viewName | String` - name of the view for which it toggles 
     - `message | String` - message for snackbar
     - `timeout | int` - numeric value in milliseconds for timeout of snackbar, defaults to 3000.
- Contains a possible fix for `#62`, requires confirmation by QA.