### PR TITLE
update graphql query to not cache

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -1063,6 +1063,7 @@ export default {
                   filters: { limit, skip, order, where },
                   where: {},
                 },
+                fetchPolicy: 'no-cache',
               })
               if (result) {
                 const formattedResult = formatGQLResult(result.data, modelName)


### PR DESCRIPTION
Remove caching from graphql requests for csv export to prevent exporting wrong data