### PR TITLE
add no-cache server middleware 1187

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -407,10 +407,6 @@ export default {
     await this.$apolloHelpers.onLogin(token, undefined, { expires: 7 })
   },
   mounted() {
-    const loginStatus = this.$auth.strategy.token.get()
-    if (!loginStatus) {
-      location.replace(`${this.$config.basePublicPath}/unauthorized`)
-    }
     const userInfo = userUtils.userCurrentOrgInfo(this.$store) || {}
     const userRoles = userInfo.roles || []
     this.allowUpgrade = userRoles.includes('$orgowner')

--- a/layouts/event.vue
+++ b/layouts/event.vue
@@ -413,10 +413,6 @@ export default {
     await this.$apolloHelpers.onLogin(token, undefined, { expires: 7 })
   },
   mounted() {
-    const loginStatus = this.$auth.strategy.token.get()
-    if (!loginStatus) {
-      location.replace(`${this.$config.basePublicPath}/unauthorized`)
-    }
     const userInfo = userUtils.userCurrentOrgInfo(this.$store) || {}
     const userRoles = userInfo.roles || []
     this.allowUser = userRoles.length === 1 && userRoles.includes('$orguser')

--- a/layouts/help-center.vue
+++ b/layouts/help-center.vue
@@ -288,10 +288,6 @@ export default {
     })
   },
   mounted() {
-    const loginStatus = this.$auth.strategy.token.get()
-    if (!loginStatus) {
-      location.replace(`${this.$config.basePublicPath}/unauthorized`)
-    }
     const userInfo = userUtils.userCurrentOrgInfo(this.$store) || {}
     const userRoles = userInfo.roles || []
     this.allowUpgrade = userRoles.includes('$orgowner')

--- a/layouts/integration.vue
+++ b/layouts/integration.vue
@@ -175,10 +175,6 @@ export default {
     await this.$apolloHelpers.onLogin(token, undefined, { expires: 7 })
   },
   mounted() {
-    const loginStatus = this.$auth.strategy.token.get()
-    if (!loginStatus) {
-      location.replace(`${this.$config.basePublicPath}/unauthorized`)
-    }
     const userInfo = userUtils.userCurrentOrgInfo(this.$store) || {}
     const userRoles = userInfo.roles || []
     this.allowUpgrade = userRoles.includes('$orgowner')

--- a/layouts/seatmap.vue
+++ b/layouts/seatmap.vue
@@ -177,10 +177,6 @@ export default {
     }
   },
   mounted() {
-    const loginStatus = this.$auth.strategy.token.get()
-    if (!loginStatus) {
-      location.replace(`${this.$config.basePublicPath}/unauthorized`)
-    }
     const userInfo = userUtils.userCurrentOrgInfo(this.$store) || {}
     const userRoles = userInfo.roles || []
     this.allowUpgrade = userRoles.includes('$orgowner')

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -334,7 +334,7 @@ export default {
       },
     },
   },
-  serverMiddleware: ['~/api/index.js'],
+  serverMiddleware: ['~/api/index.js', '~/server-middleware/no-cache'],
   auth: {
     redirect: {
       login: '/login',

--- a/server-middleware/no-cache.js
+++ b/server-middleware/no-cache.js
@@ -1,0 +1,8 @@
+export default function (req, res, next) {
+  if (req.url === '/apps/event/eventboard') {
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
+    res.setHeader('Pragma', 'no-cache')
+    res.setHeader('Expires', '0')
+  }
+  next()
+}


### PR DESCRIPTION
- prevents `/eventboard` from being cached and prevent `auth` check on back button.