### PR TITLE
Fixed issue of default template getting wrong name saved

### DIFF
--- a/pages/apps/_app/event/_id/editSiteSetting.vue
+++ b/pages/apps/_app/event/_id/editSiteSetting.vue
@@ -351,7 +351,7 @@ export default {
       if (this.eventData.BusinessType === 'Recurring') {
         this.selectTemplate('Dark')
       } else {
-        this.selectTemplate('Event')
+        this.selectTemplate('event')
       }
     },
     changeTab() {


### PR DESCRIPTION
Fixed:
1283 :on registration page getting old event template



