### PR TITLE
update no message logic to avoid wrong messages

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -657,10 +657,8 @@ export default {
       footerObserver: null,
       winWidth: window.innerWidth,
       itemPerPage: 0,
-      componentRerenderKey: 0,
-      noDataText: this.hasCustomNoDataText
-        ? this.hasCustomNoDataText
-        : this.$t('Common.NoDataAvailable'),
+      componentRerenderKey: `${this.viewName}-init`,
+      noDataText: this.$t('Common.NoDataAvailable'),
     }
   },
   computed: {
@@ -773,6 +771,11 @@ export default {
       }
       return false
     },
+    eveId() {
+      return this.$route.params.app === 'event'
+        ? this.$route.params.id || ''
+        : ''
+    },
   },
   watch: {
     filters() {
@@ -787,6 +790,12 @@ export default {
     value() {
       this.selectedItems = this.value
     },
+    hasCustomNoDataText() {
+      this.noDataText = this.hasCustomNoDataText
+        ? this.hasCustomNoDataText
+        : this.$t('Common.NoDataAvailable')
+      this.componentRerenderKey = `${this.viewName}-${this.eveId}-nodatatextupdated-${this.hasCustomNoDataText}`
+    },
   },
   mounted() {
     setTimeout(() => {
@@ -796,6 +805,9 @@ export default {
     this.$eventBus.$on('eventInvites-grid-refresh', this.refreshGrid)
     this.$eventBus.$on('toggle-snackbar', this.toggleSnackbar)
     this.$eventBus.$on('toggle-confirm', this.toggleConfirm)
+    this.noDataText = this.hasCustomNoDataText
+      ? this.hasCustomNoDataText
+      : this.$t('Common.NoDataAvailable')
     if (this.loadRestData) {
       this.$eventBus.$on('user-created', this.loadRestData)
     }
@@ -816,8 +828,8 @@ export default {
         [`templates/grids/${this.templateFolderName}/${slot}.vue`],
         false
       )
-      this.componentRerenderKey += this.slotTemplates.body ? 1 : 0
     })
+    this.componentRerenderKey = `${this.viewName}-${this.eveId}-slotsfetched`
     const templateName = this.templateFolderName
     ACTION_TYPES.forEach(async (actionType) => {
       this.actionTemplates[actionType] = await this.loadTemplate([
@@ -1226,7 +1238,7 @@ export default {
           this.noDataText = this.hasCustomNoDataText
             ? this.hasCustomNoDataText
             : this.$t('Common.NoDataAvailable')
-          this.componentRerenderKey += this.slotTemplates.body ? 1 : 0
+          this.componentRerenderKey = `${this.viewName}-${this.eveId}-restfetched`
           this.loading = false
         } catch (e) {
           console.error(
@@ -1293,7 +1305,7 @@ export default {
               }
             : {}
         if (Object.keys(data).length > 0) this.error = ''
-        this.componentRerenderKey += this.slotTemplates.body ? 1 : 0
+        this.componentRerenderKey = `${this.viewName}-${this.eveId}-dataloaded`
         return tableData
       },
       result({ data, loading, networkStatus }) {

--- a/pages/apps/_app/event/_id/index.vue
+++ b/pages/apps/_app/event/_id/index.vue
@@ -1670,7 +1670,9 @@ export default {
       otherFileId: '',
       isMakeCopy: false,
       data: {
-        event: {},
+        event: {
+          HasTickets: true,
+        },
         badge: {},
         eventSummary: {},
       },


### PR DESCRIPTION
- Found out that the parameter from old event got cached which caused them to be supplied to props for new grids momentarily before new data is fetched and updated. Adding a watcher to the prop allowed to update the data once new values are sent via props.
- also updates logic for how keys are assigned to data tables, further improvements for `#62`.
