### PR TITLE
added code to emit the grid clear on clicking the resetButton

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -1205,7 +1205,7 @@ export default {
       this.selectedItems = []
     },
     unselectAllRecord(viewName) {
-      if (viewName === this.viewName) {
+      if (viewName === this.viewName || viewName === 'inviteeEventTasks') {
         this.selectedItems = []
       }
     },

--- a/config/templates/grids/eventInvites-grid/actions/grid/sendEventInvite.vue
+++ b/config/templates/grids/eventInvites-grid/actions/grid/sendEventInvite.vue
@@ -421,11 +421,7 @@
                         class="ml-10"
                         text
                         small
-                        @click="
-                          registrationRadio = ''
-                          openRadio = ''
-                          priorInvite = {}
-                        "
+                        @click="onResetPriorInvitee"
                       >
                         <v-icon dark left>mdi-replay</v-icon>
                         <i18n path="Drawer.Reset" />
@@ -788,8 +784,10 @@
     </v-dialog>
     <v-dialog v-model="previousInviteDialog" width="600px">
       <v-card>
-        <v-card-title class="d-flex align-start px-2 pl-4 p-0">
-          <h2 class="black--text pt-0 pb-0 text-h5">
+        <v-card-title
+          class="pl-md-10 pl-lg-10 pl-xl-15 pr-1 pb-0 pt-1 d-flex align-start"
+        >
+          <h2 class="black--text pt-4 pb-2 ml-n1 text-h5">
             <i18n path="Common.SelectPriorInvite" />
           </h2>
           <v-spacer></v-spacer>
@@ -799,7 +797,7 @@
             </v-btn>
           </div>
         </v-card-title>
-        <v-container class="pt-0 px-4">
+        <v-container class="pt-0 px-4 pb-8 inviteeDialog">
           <Grid
             v-if="!editDraft"
             view-name="inviteeEventTasks"
@@ -992,6 +990,12 @@ export default {
     this.$eventBus.$off('itemSelected')
   },
   methods: {
+    onResetPriorInvitee() {
+      this.registrationRadio = ''
+      this.openRadio = ''
+      this.priorInvite = {}
+      this.$eventBus.$emit('unselectAll-record', 'inviteeEventTasks')
+    },
     onPrev() {
       this.curentTab--
       document.getElementsByClassName('invite-inner')[0].scrollTop = 0


### PR DESCRIPTION
Fixed:
1296:Fixed the UI of the preInvitee form
1297:Not able to select the prior invite second time while sending an email invite from event detail view-The problem with this issue was that when user was trying to reset the preinvitee form dialog data but on reset the grid was not able to know that the data was reset and the grid must reset the selected data.So i tried to emit an event which have been used to reset the grid data.

