### PR TITLE
Bug send event invitee preinvitee

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -1217,8 +1217,8 @@ export default {
       this.selectedItems = []
     },
     unselectAllRecord(viewName) {
-      if (viewName === this.viewName || viewName === 'inviteeEventTasks') {
-        this.selectedItems = []
+      if (viewName === 'inviteeEventTasks') {
+        this.refreshGrid(viewName)
       }
     },
     async loadRestData() {

--- a/components/newRecurringEvent.vue
+++ b/components/newRecurringEvent.vue
@@ -1751,6 +1751,7 @@ export default {
       this.isGroup = value === 'Group'
     },
     changelocationType(index) {
+      debugger
       return () => {
         this.selectedSession = index
         if (this.sessions[index].LocationType === 'Phone call') {
@@ -1804,6 +1805,12 @@ export default {
           this.isLocationMessage = false
         }
         if (this.sessions[index].LocationType === 'Ask invitee') {
+          this.isGoogleMeet = false
+          this.isZoom = false
+          this.isLocationMessage = false
+        }
+        if (this.sessions[index].LocationType === 'Bitpod Virtual') {
+          debugger
           this.isGoogleMeet = false
           this.isZoom = false
           this.isLocationMessage = false

--- a/components/newRecurringEvent.vue
+++ b/components/newRecurringEvent.vue
@@ -1751,7 +1751,6 @@ export default {
       this.isGroup = value === 'Group'
     },
     changelocationType(index) {
-      debugger
       return () => {
         this.selectedSession = index
         if (this.sessions[index].LocationType === 'Phone call') {
@@ -1810,7 +1809,6 @@ export default {
           this.isLocationMessage = false
         }
         if (this.sessions[index].LocationType === 'Bitpod Virtual') {
-          debugger
           this.isGoogleMeet = false
           this.isZoom = false
           this.isLocationMessage = false

--- a/config/templates/grids/allEvents-grid/actions/row-select/edit-item.vue
+++ b/config/templates/grids/allEvents-grid/actions/row-select/edit-item.vue
@@ -1,8 +1,5 @@
 <template>
   <v-col class="px-0">
-    <v-snackbar v-model="snackbar" :timeout="timeout" :top="true">
-      <div class="text-center">{{ snackbarText }}</div>
-    </v-snackbar>
     <v-dialog
       v-model="dialog"
       persistent
@@ -433,6 +430,10 @@ export default {
       required: false,
       default: () => false,
     },
+    viewName: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
@@ -491,6 +492,9 @@ export default {
       status: '',
       privacy: '',
       currency: '',
+      snackbar: false,
+      snackbarText: this.$t('Messages.Success.EventDetailsUpdateSuccess'),
+      timeout: '3000',
     }
   },
   computed: {
@@ -723,7 +727,13 @@ export default {
           })
           if (res) {
             this.onClose()
-            this.refresh()
+
+            this.$eventBus.$emit(
+              'toggle-snackbar',
+              this.viewName,
+              this.snackbarText,
+              3000
+            )
             this.data.event = res
           }
         } catch (e) {
@@ -744,7 +754,12 @@ export default {
           })
           if (res) {
             this.onClose()
-            this.refresh()
+            this.$eventBus.$emit(
+              'toggle-snackbar',
+              this.viewName,
+              this.snackbarText,
+              3000
+            )
             return (this.data.event = res)
           }
         } catch (e) {

--- a/config/templates/grids/eventInvites-grid/actions/grid/sendEventInvite.vue
+++ b/config/templates/grids/eventInvites-grid/actions/grid/sendEventInvite.vue
@@ -1166,6 +1166,7 @@ export default {
         postData.Status = type
       }
       if (type === 'Draft') {
+        postData.ParentId = this.priorInvite.id
         postData.Status = type
       }
       if (this.selectAll) {

--- a/config/templates/grids/eventInvites-grid/actions/grid/test4.html
+++ b/config/templates/grids/eventInvites-grid/actions/grid/test4.html
@@ -1,0 +1,1650 @@
+<p>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400&display=swap');
+    .ban-img {
+      width: 100%;
+      height: auto;
+    }
+
+    .banicon {
+      margin-right: 10px;
+      width: 25px;
+    }
+
+    .sessionList table,
+    .attendeeList table {
+      width: 80%;
+    }
+
+    .sessionList td,
+    th,
+    tr {
+      padding: 2px 10px !important;
+    }
+
+    .attendeeList td,
+    th,
+    tr {
+      padding: 2px 10px !important;
+    }
+
+    .in-table {
+      width: 70%;
+    }
+
+    @media only screen and (max-width: 640px) {
+      .in-table {
+        width: 100% !important;
+      }
+    }
+  </style>
+</p>
+<table
+  style="min-width: 100%; font-family: 'Roboto', sans-serif;"
+  width="100%"
+  bgcolor="#fff"
+  class="general-template"
+>
+  <tbody>
+    <tr>
+      <td>
+        <table
+          class="in-table"
+          style="
+            margin-left: auto;
+            margin-right: auto;
+            border-collapse: collapse;
+            border-spacing: 0;
+            border: 1px solid #ccc;
+            padding: 0;
+          "
+          cellpadding="0"
+          cellspacing="0"
+          border="0"
+        >
+          <tbody>
+            <tr>
+              <td
+                style="margin-left: auto; margin-right: auto;"
+                align="center"
+                bgcolor="#fff"
+              >
+                <table style="border: none;">
+                  <tbody>
+                    <tr>
+                      <td align="center" bgcolor="#fff">
+                        <table
+                          cellpadding="0"
+                          cellspacing="0"
+                          border="0"
+                          bgcolor="#EEEDF2"
+                          style="margin-top: 5px;"
+                        >
+                          <tbody>
+                            <tr bgcolor="#FFFFFF">
+                              <td
+                                style="background-color: #ffffff;"
+                                bgcolor="#FFFFFF"
+                              >
+                                <table
+                                  style="
+                                    border-collapse: collapse;
+                                    border-spacing: 0;
+                                    border: 0;
+                                    padding: 0;
+                                    width: 100%;
+                                  "
+                                  align="left"
+                                >
+                                  <tbody>
+                                    <tr bgcolor="#FFFFFF">
+                                      <td width="20" bgcolor="#FFFFFF">
+                                        <br />
+                                      </td>
+                                      <td
+                                        style="
+                                          text-align: left;
+                                          background-color: #ffffff;
+                                        "
+                                        align="left"
+                                      >
+                                        <br />
+                                        <br /><br /><br />
+                                        <br />
+                                        <table
+                                          style="
+                                            border-collapse: collapse;
+                                            border-spacing: 0;
+                                            border: 0;
+                                            padding: 0;
+                                            width: 100%;
+                                          "
+                                          cellspacing="0"
+                                          cellpadding="0"
+                                          bgcolor="#FFFFFF"
+                                          align="left"
+                                        >
+                                          <tbody>
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: center;
+                                                "
+                                                align="center"
+                                                bgcolor=""
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <div
+                                                  style="
+                                                    width: 140px;
+                                                    height: auto;
+                                                    margin: 0 auto;
+                                                    text-align: center;
+                                                    margin-bottom: 10px;
+                                                  "
+                                                >
+                                                  <img
+                                                    style="
+                                                      max-width: 200px;
+                                                      height: auto;
+                                                    "
+                                                    src="https://res.cloudinary.com/mytestlogo/admin-default-template-logo.png"
+                                                    title=""
+                                                    alt="${Organization.name ||''}"
+                                                    width="140"
+                                                    class="ban-img img-responsive badgelogoimg"
+                                                  />
+                                                </div>
+                                              </td>
+                                            </tr>
+
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <h2
+                                                  style="
+                                                    padding: 0;
+                                                    margin: 12px 0 0 0;
+                                                    font-size: 28px;
+                                                    line-height: 40px;
+                                                    font-weight: normal;
+                                                    font-weight: 300;
+                                                    font-family: 'Roboto',
+                                                      'Helvetica Neue',
+                                                      Helvetica, Arial,
+                                                      sans-serif;
+                                                    margin-top: 5px;
+                                                    text-align: center;
+                                                    margin-bottom: 15px;
+                                                    font-family: 'Roboto',
+                                                      sans-serif;
+                                                    font-weight: 300;
+                                                  "
+                                                >
+                                                  <div
+                                                    style="
+                                                      text-transform: capitalize;
+                                                    "
+                                                  >
+                                                    ${Registration.FirstName ||
+                                                    ""} ${Registration.LastName
+                                                    || ""}
+                                                  </div>
+                                                  <div
+                                                    style="
+                                                      font-size: 18px;
+                                                      line-height: 20px;
+                                                      font-weight: normal;
+                                                      color: #6f7287;
+                                                      font-family: 'Roboto',
+                                                        sans-serif;
+                                                      font-weight: 300;
+                                                    "
+                                                  >
+                                                    We look forward to your
+                                                    participation
+                                                  </div>
+                                                </h2>
+                                              </td>
+                                            </tr>
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <h2
+                                                  style="
+                                                    padding: 0;
+                                                    margin: 12px 0 0 0;
+                                                    font-size: 23px;
+                                                    line-height: 32px;
+                                                    font-weight: normal;
+                                                    font-weight: 400;
+                                                    color: #464646;
+                                                    font-family: 'Roboto',
+                                                      'Helvetica Neue',
+                                                      Helvetica, Arial,
+                                                      sans-serif;
+                                                    margin-top: 0;
+                                                    text-align: center;
+                                                    font-family: 'Roboto',
+                                                      sans-serif;
+                                                  "
+                                                >
+                                                  <span>${Event.Title}</span>
+                                                </h2>
+                                                <div
+                                                  style="
+                                                    font-size: 15px;
+                                                    line-height: 20px;
+                                                    font-weight: normal;
+                                                    color: #6f7287;
+                                                    text-align: center;
+                                                  "
+                                                >
+                                                  Organized by
+                                                  ${Event.Organizer}
+                                                </div>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 12px;
+                                                  font-size: 12px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="12"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 12px;
+                                                    font-size: 12px;
+                                                    height: 12px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="12"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 24px;
+                                                          font-size: 24px;
+                                                          height: 24px;
+                                                        "
+                                                        height="24"
+                                                        bgcolor=""
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <img
+                                                  src="https://res.cloudinary.com/mytestlogo/default-min.jpg"
+                                                  width="100%"
+                                                  height="auto"
+                                                  class="ban-img bannerImage"
+                                                  style="
+                                                    undefined: undefined;
+                                                    max-height: 220px;
+                                                    max-width: 700px;
+                                                  "
+                                                />
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 12px;
+                                                  font-size: 12px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="12"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 12px;
+                                                    font-size: 12px;
+                                                    height: 12px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="12"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 24px;
+                                                          font-size: 24px;
+                                                          height: 24px;
+                                                        "
+                                                        height="24"
+                                                        bgcolor=""
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <br />
+                                              </td>
+                                            </tr>
+                                            <tr bgcolor="#FFFFFF">
+                                              <td
+                                                style="
+                                                  background-color: #ffffff;
+                                                "
+                                                bgcolor="#FFFFFF"
+                                              >
+                                                <table
+                                                  style="
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  align="left"
+                                                >
+                                                  <tbody>
+                                                    <tr bgcolor="#FFFFFF">
+                                                      <td
+                                                        style="
+                                                          text-align: left;
+                                                          background-color: #ffffff;
+                                                        "
+                                                        align="left"
+                                                      >
+                                                        <table
+                                                          style="
+                                                            border-collapse: collapse;
+                                                            border-spacing: 0;
+                                                            border: 0;
+                                                            padding: 0;
+                                                            width: 100%;
+                                                          "
+                                                          cellspacing="0"
+                                                          cellpadding="0"
+                                                          bgcolor="#FFFFFF"
+                                                          align="left"
+                                                        >
+                                                          <tbody>
+                                                            <tr bgcolor="white">
+                                                              <td
+                                                                style="
+                                                                  padding: 0;
+                                                                  text-align: left;
+                                                                "
+                                                                align="left"
+                                                                bgcolor="white"
+                                                                width="100%"
+                                                                height=""
+                                                              >
+                                                                <br />
+                                                                <br />
+                                                                <br />
+                                                                <table
+                                                                  cellpadding="0"
+                                                                  cellspacing="0"
+                                                                  border="0"
+                                                                  width="100%"
+                                                                  style="
+                                                                    border-spacing: 0;
+                                                                    border-collapse: collapse;
+                                                                  "
+                                                                >
+                                                                  <tbody>
+                                                                    <tr>
+                                                                      <td
+                                                                        colspan="3"
+                                                                      >
+                                                                        <span
+                                                                          style="
+                                                                            font-weight: normal;
+                                                                            margin: 4px
+                                                                              0;
+                                                                            font-size: 15px;
+                                                                            line-height: 21px;
+                                                                            font-family: 'Roboto',
+                                                                              'Helvetica Neue',
+                                                                              Helvetica,
+                                                                              Arial,
+                                                                              sans-serif;
+                                                                            color: #6f7287;
+                                                                          "
+                                                                        >
+                                                                          Registration
+                                                                          Id
+                                                                          <a
+                                                                            style="
+                                                                              text-decoration: none;
+                                                                              color: #3f60e7;
+                                                                              font-family: 'Roboto',
+                                                                                'Helvetica Neue',
+                                                                                Helvetica,
+                                                                                Arial,
+                                                                                sans-serif;
+                                                                              font-weight: normal;
+                                                                            "
+                                                                            href=""
+                                                                            target="_blank"
+                                                                            >${Registration.RegistrationId
+                                                                            ||
+                                                                            ""}</a
+                                                                          >
+                                                                        </span>
+                                                                      </td>
+                                                                    </tr>
+                                                                    <tr>
+                                                                      <td
+                                                                        colspan="3"
+                                                                      >
+                                                                        <br />
+                                                                      </td>
+                                                                    </tr>
+                                                                    <tr>
+                                                                      <td
+                                                                        style="
+                                                                          line-height: 8px;
+                                                                          font-size: 8px;
+                                                                          background-color: #ffffff;
+                                                                        "
+                                                                        width="600"
+                                                                        height="8"
+                                                                      >
+                                                                        <br />
+                                                                        <table
+                                                                          style="
+                                                                            line-height: 8px;
+                                                                            font-size: 8px;
+                                                                            height: 8px;
+                                                                            border-collapse: collapse;
+                                                                            border-spacing: 0;
+                                                                            border: 0;
+                                                                            padding: 0;
+                                                                            width: 100%;
+                                                                          "
+                                                                          cellspacing="0"
+                                                                          cellpadding="0"
+                                                                          height="8"
+                                                                        >
+                                                                          <tbody>
+                                                                            <tr>
+                                                                              <td
+                                                                                style="
+                                                                                  line-height: 16px;
+                                                                                  font-size: 16px;
+                                                                                  height: 16px;
+                                                                                "
+                                                                                height="16"
+                                                                                bgcolor=""
+                                                                              >
+                                                                                <br />
+                                                                              </td>
+                                                                            </tr>
+                                                                          </tbody>
+                                                                        </table>
+                                                                      </td>
+                                                                    </tr>
+
+                                                                    <tr
+                                                                      bgcolor="white"
+                                                                    >
+                                                                      <td
+                                                                        style="
+                                                                          padding: 0;
+                                                                          text-align: left;
+                                                                        "
+                                                                        align="left"
+                                                                        bgcolor="white"
+                                                                        width="100%"
+                                                                        height=""
+                                                                      ></td>
+                                                                    </tr>
+                                                                    <tr>
+                                                                      <td
+                                                                        style="
+                                                                          line-height: 15px;
+                                                                          font-size: 24px;
+                                                                          height: 15px;
+                                                                        "
+                                                                        height="24"
+                                                                        bgcolor=""
+                                                                      >
+                                                                        <br />
+                                                                      </td>
+                                                                    </tr>
+                                                                  </tbody>
+                                                                </table>
+                                                              </td>
+                                                            </tr>
+                                                          </tbody>
+                                                        </table>
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <br />
+                                              </td>
+                                            </tr>
+
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 12px;
+                                                  font-size: 12px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="12"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 12px;
+                                                    font-size: 12px;
+                                                    height: 12px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="12"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 24px;
+                                                          font-size: 24px;
+                                                          height: 24px;
+                                                        "
+                                                        height="24"
+                                                        bgcolor=""
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <table
+                                                  style="
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        width="26"
+                                                        style="
+                                                          vertical-align: top;
+                                                          padding-right: 15px;
+                                                        "
+                                                      >
+                                                        <img
+                                                          src="https://res.cloudinary.com/mytestlogo/image/upload/v1580450302/clockicon.png"
+                                                          style="
+                                                            padding-top: 5px;
+                                                          "
+                                                          width="25"
+                                                          height=""
+                                                          class="ban-img banicon"
+                                                        />
+                                                      </td>
+                                                      <td>
+                                                        <table>
+                                                          <tbody>
+                                                            <tr bgcolor="white">
+                                                              <td
+                                                                style="
+                                                                  padding: 0;
+                                                                  text-align: left;
+                                                                "
+                                                                align="left"
+                                                                bgcolor="white"
+                                                                width="100%"
+                                                                height="22px"
+                                                              >
+                                                                <span
+                                                                  style="
+                                                                    font-weight: normal;
+                                                                    margin: 4px
+                                                                      0;
+                                                                    font-size: 17px;
+                                                                    line-height: 24px;
+                                                                    font-family: 'Roboto',
+                                                                      'Helvetica Neue',
+                                                                      Helvetica,
+                                                                      Arial,
+                                                                      sans-serif;
+                                                                    color: #1e0a3c;
+                                                                    font-weight: normal;
+                                                                    text-decoration: none;
+                                                                  "
+                                                                >
+                                                                  ${Event.SDate
+                                                                  || ""} -
+                                                                  ${Event.EDate
+                                                                  || ""}
+                                                                  ${Event.Timezone
+                                                                  || ""}
+                                                                </span>
+                                                              </td>
+                                                            </tr>
+                                                            <tr bgcolor="white">
+                                                              <td
+                                                                style="
+                                                                  padding: 0;
+                                                                  font-size: 15px;
+                                                                  line-height: 21px;
+                                                                  text-align: left;
+                                                                "
+                                                                align="left"
+                                                                bgcolor="white"
+                                                                width="100%"
+                                                                height="22px"
+                                                              >
+                                                                <span
+                                                                  style="
+                                                                    font-weight: normal;
+                                                                    margin: 4px
+                                                                      0;
+                                                                    font-size: 15px;
+                                                                    line-height: 21px;
+                                                                    font-family: 'Roboto',
+                                                                      'Helvetica Neue',
+                                                                      Helvetica,
+                                                                      Arial,
+                                                                      sans-serif;
+                                                                    color: #6f7287;
+                                                                    font-weight: normal;
+                                                                  "
+                                                                >
+                                                                  Add to
+                                                                  <a
+                                                                    style="
+                                                                      text-decoration: none;
+                                                                      color: #3f60e7;
+                                                                      font-family: 'Roboto',
+                                                                        'Helvetica Neue',
+                                                                        Helvetica,
+                                                                        Arial,
+                                                                        sans-serif;
+                                                                      font-weight: normal;
+                                                                    "
+                                                                    href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text=${encodeURIComponent(Event.Title)}&amp;dates=${new Date(Event.ISOStartDate).toISOString().replace(/[-:]/g,'').substr(0,15)}Z/${new Date(Event.ISOEndDate).toISOString().replace(/[-:]/g,'').substr(0,15)}Z&amp;location=${encodeURI(Event.VenueName|| '')} ${encodeURI(Event._VenueAddress.AddressLine|| '')} ${encodeURI(Event._VenueAddress.City|| '')} ${encodeURI(Event._VenueAddress.State|| '')} ${encodeURI(Event._VenueAddress.Country|| '')} ${encodeURI(Event._VenueAddress.PostalCode|| '')}"
+                                                                    target="_blank"
+                                                                    >Google
+                                                                  </a>
+                                                                  <span
+                                                                    style="
+                                                                      display: inline;
+                                                                    "
+                                                                    >·</span
+                                                                  >
+
+                                                                  <a
+                                                                    style="
+                                                                      text-decoration: none;
+                                                                      color: #3f60e7;
+                                                                      font-family: 'Roboto',
+                                                                        'Helvetica Neue',
+                                                                        Helvetica,
+                                                                        Arial,
+                                                                        sans-serif;
+                                                                      font-weight: normal;
+                                                                    "
+                                                                    clicktracking="off"
+                                                                    href="https://${Organization.name||''}-event.test.bitpod.io/svc/api/Events/calendar?eventId=${Event.id}"
+                                                                    >iCal
+                                                                  </a>
+                                                                  <span>·</span>
+                                                                </span>
+                                                              </td>
+                                                            </tr>
+                                                          </tbody>
+                                                        </table>
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 12px;
+                                                  font-size: 12px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="12"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 12px;
+                                                    font-size: 12px;
+                                                    height: 12px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="12"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 24px;
+                                                          font-size: 24px;
+                                                          height: 24px;
+                                                        "
+                                                        height="24"
+                                                        bgcolor=""
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <table
+                                                  style="
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        width="26"
+                                                        style="
+                                                          vertical-align: top;
+                                                          padding-right: 15px;
+                                                        "
+                                                      >
+                                                        <img
+                                                          src="https://res.cloudinary.com/mytestlogo/mapicon.png"
+                                                          style="
+                                                            padding-top: 5px;
+                                                          "
+                                                          width="25"
+                                                          height=""
+                                                          class="ban-img banicon"
+                                                        />
+                                                      </td>
+                                                      <td>
+                                                        <table>
+                                                          <tbody>
+                                                            <tr bgcolor="white">
+                                                              <td
+                                                                style="
+                                                                  padding: 0;
+                                                                  font-size: 15px;
+                                                                  line-height: 21px;
+                                                                  text-align: left;
+                                                                "
+                                                                align="left"
+                                                                bgcolor="white"
+                                                                width="100%"
+                                                              >
+                                                                <span
+                                                                  style="
+                                                                    font-weight: normal;
+                                                                    margin: 4px
+                                                                      0;
+                                                                    font-size: 17px;
+                                                                    line-height: 24px;
+                                                                    font-family: 'Roboto',
+                                                                      'Helvetica Neue',
+                                                                      Helvetica,
+                                                                      Arial,
+                                                                      sans-serif;
+                                                                    color: #1e0a3c;
+                                                                    font-weight: normal;
+                                                                  "
+                                                                >
+                                                                  ${Event.VenueName
+                                                                  || ""}
+                                                                </span>
+                                                              </td>
+                                                            </tr>
+                                                            <tr bgcolor="white">
+                                                              <td
+                                                                style="
+                                                                  padding: 0;
+                                                                  font-size: 15px;
+                                                                  line-height: 21px;
+                                                                  text-align: left;
+                                                                "
+                                                                align="left"
+                                                                bgcolor="white"
+                                                                width="100%"
+                                                              >
+                                                                <span
+                                                                  style="
+                                                                    font-weight: normal;
+                                                                    margin: 4px
+                                                                      0;
+                                                                    font-size: 15px;
+                                                                    line-height: 21px;
+                                                                    font-family: 'Roboto',
+                                                                      'Helvetica Neue',
+                                                                      Helvetica,
+                                                                      Arial,
+                                                                      sans-serif;
+                                                                    color: #6f7287;
+                                                                    font-weight: normal;
+                                                                    display: block;
+                                                                    max-width: 600px;
+                                                                  "
+                                                                >
+                                                                  ${Event._VenueAddress.AddressLine
+                                                                  || ""}
+                                                                  ${Event._VenueAddress.City
+                                                                  || ""}
+                                                                  ${Event._VenueAddress.State
+                                                                  || ""}
+                                                                  ${Event._VenueAddress.Country
+                                                                  || ""}<br />
+                                                                  ${Event._VenueAddress.PostalCode
+                                                                  || ""}
+                                                                </span>
+                                                              </td>
+                                                            </tr>
+
+                                                            <tr>
+                                                              <td
+                                                                height="22px"
+                                                                style="
+                                                                  font-size: 15px;
+                                                                  line-height: 21px;
+                                                                "
+                                                              >
+                                                                <a
+                                                                  style="
+                                                                    text-decoration: none;
+                                                                    color: #3f60e7;
+                                                                    font-family: 'Roboto',
+                                                                      'Helvetica Neue',
+                                                                      Helvetica,
+                                                                      Arial,
+                                                                      sans-serif;
+                                                                    font-weight: normal;
+                                                                  "
+                                                                  href="${viewonmap}"
+                                                                  >View on
+                                                                  map</a
+                                                                >
+                                                              </td>
+                                                            </tr>
+                                                          </tbody>
+                                                        </table>
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 12px;
+                                                  font-size: 12px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="12"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 12px;
+                                                    font-size: 12px;
+                                                    height: 12px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="12"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 24px;
+                                                          font-size: 24px;
+                                                          height: 24px;
+                                                        "
+                                                        height="24"
+                                                        bgcolor=""
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                ${sessionList}
+
+                                                <br />
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td
+                                                height="22px"
+                                                style="
+                                                  font-size: 15px;
+                                                  line-height: 21px;
+                                                  undefined: undefined;
+                                                  text-align: center;
+                                                  padding-top: 15px;
+                                                "
+                                              >
+                                                <span
+                                                  style="
+                                                    font-weight: normal;
+                                                    margin: 4px 0;
+                                                    font-size: 14px;
+                                                    line-height: 20px;
+                                                    font-family: 'Roboto',
+                                                      'Helvetica Neue',
+                                                      Helvetica, Arial,
+                                                      sans-serif;
+                                                    color: #1e0a3c;
+                                                    font-weight: 400;
+                                                  "
+                                                >
+                                                  Visit the attendees
+                                                  <a
+                                                    style="
+                                                      text-decoration: none;
+                                                      color: #3f60e7;
+                                                      color: #3f60e7;
+                                                      font-family: 'Roboto',
+                                                        'Helvetica Neue',
+                                                        Helvetica, Arial,
+                                                        sans-serif;
+                                                      font-weight: normal;
+                                                      font-weight: bold;
+                                                    "
+                                                    href="https://${Organization.name||''}-event.test.bitpod.io/admin/apps/event/attendee/${Registration.id}"
+                                                    target="_blank"
+                                                    >Lounge</a
+                                                  >
+                                                  to join online sessions or
+                                                  <a
+                                                    style="
+                                                      text-decoration: none;
+                                                      color: #3f60e7;
+                                                      font-family: 'Roboto',
+                                                        'Helvetica Neue',
+                                                        Helvetica, Arial,
+                                                        sans-serif;
+                                                      font-weight: bold;
+                                                    "
+                                                    href="https://${Organization.name||''}-event.test.bitpod.io/events/${Event.SEOTitle|| ''}-${Event.id}"
+                                                  >
+                                                    Registration site</a
+                                                  >
+                                                  for more information
+                                                </span>
+                                              </td>
+                                            </tr>
+
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 12px;
+                                                  font-size: 12px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="12"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 12px;
+                                                    font-size: 12px;
+                                                    height: 12px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="12"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 24px;
+                                                          font-size: 24px;
+                                                          height: 24px;
+                                                        "
+                                                        height="24"
+                                                        bgcolor=""
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 1px;
+                                                  font-size: 1px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="1"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 1px;
+                                                    font-size: 1px;
+                                                    height: 1px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="1"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 1px;
+                                                          font-size: 1px;
+                                                          height: 1px;
+                                                        "
+                                                        height="1"
+                                                        bgcolor="#E7E6EA"
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 12px;
+                                                  font-size: 12px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="12"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 12px;
+                                                    font-size: 12px;
+                                                    height: 12px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="12"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 24px;
+                                                          font-size: 24px;
+                                                          height: 24px;
+                                                        "
+                                                        height="24"
+                                                        bgcolor=""
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: center;
+                                                  text-align: center;
+                                                  align-items: center;
+                                                "
+                                                align="center"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <img
+                                                  src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&amp;data= Registration Id:${Registration.RegistrationId} ,Event Id:${Event.id} ,Event Name:${Event.Title} ,First Name:${Registration.FullName} ,Email:${Registration.Email}, Mobile: ${Registration.Phone} "
+                                                  style="
+                                                    outline: none;
+                                                    display: block;
+                                                    text-decoration: none;
+                                                    margin: 0 auto;
+                                                  "
+                                                  alt="image"
+                                                />
+                                              </td>
+                                            </tr>
+
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: center;
+                                                "
+                                                align="center"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <h2
+                                                  style="
+                                                    padding: 0;
+                                                    margin: 12px 0 20px 0;
+                                                    font-size: 14px;
+                                                    line-height: 16px;
+                                                    font-weight: normal;
+                                                    font-weight: 500;
+                                                    color: #1e0a3c;
+                                                    font-family: 'Roboto',
+                                                      'Helvetica Neue',
+                                                      Helvetica, Arial,
+                                                      sans-serif;
+                                                    margin-top: 5px;
+                                                  "
+                                                >
+                                                  Bring printout of this email
+                                                  OR show this on your
+                                                  smartphone, at the event venue
+                                                </h2>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 1px;
+                                                  font-size: 1px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="1"
+                                              >
+                                                <br />
+                                                <table
+                                                  style="
+                                                    line-height: 1px;
+                                                    font-size: 1px;
+                                                    height: 1px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="1"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 1px;
+                                                          font-size: 1px;
+                                                          height: 1px;
+                                                        "
+                                                        height="1"
+                                                        bgcolor="#E7E6EA"
+                                                      >
+                                                        <br />
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 12px;
+                                                  font-size: 12px;
+                                                  background-color: #ffffff;
+                                                "
+                                                width="600"
+                                                height="12"
+                                              >
+                                                <table
+                                                  style="
+                                                    line-height: 12px;
+                                                    font-size: 12px;
+                                                    height: 12px;
+                                                    border-collapse: collapse;
+                                                    border-spacing: 0;
+                                                    border: 0;
+                                                    padding: 0;
+                                                    width: 100%;
+                                                  "
+                                                  cellspacing="0"
+                                                  cellpadding="0"
+                                                  height="12"
+                                                >
+                                                  <tbody>
+                                                    <tr>
+                                                      <td
+                                                        style="
+                                                          line-height: 24px;
+                                                          font-size: 18px;
+                                                          height: 24px;
+                                                          font-family: 'Roboto',
+                                                            sans-serif;
+                                                        "
+                                                        height="24"
+                                                        bgcolor=""
+                                                      >
+                                                        ${paymentDetailsTitle}
+                                                      </td>
+                                                    </tr>
+                                                  </tbody>
+                                                </table>
+                                              </td>
+                                            </tr>
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: left;
+                                                "
+                                                align="left"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                ${paymentDetails}
+
+                                                <br />
+                                              </td>
+                                            </tr>
+
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: center;
+                                                "
+                                                align="center"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <h2
+                                                  style="
+                                                    padding: 0;
+                                                    margin: 12px 0 0 0;
+                                                    font-size: 17px;
+                                                    line-height: 23px;
+                                                    font-weight: normal;
+                                                    font-weight: 500;
+                                                    color: #1e0a3c;
+                                                    font-family: 'Roboto',
+                                                      'Helvetica Neue',
+                                                      Helvetica, Arial,
+                                                      sans-serif;
+                                                    margin-top: 0;
+                                                  "
+                                                >
+                                                  ${OrganizationInfo.Email ?
+                                                  "Need any Help?" : ""}
+                                                </h2>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <br />
+                                            </tr>
+
+                                            <tr bgcolor="white">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: center;
+                                                "
+                                                align="center"
+                                                bgcolor="white"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                Write us at
+                                                <a
+                                                  style="
+                                                    text-decoration: none;
+                                                    color: #3f60e7;
+                                                    font-family: 'Helvetica Neue',
+                                                      Helvetica, Arial,
+                                                      sans-serif;
+                                                    font-weight: normal;
+                                                  "
+                                                >
+                                                  ${OrganizationInfo.Email ||
+                                                  ""}</a
+                                                >
+                                                and we will get back to you
+                                                shortly!
+                                              </td>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                      </td>
+                                      <td width="20" bgcolor="#FFFFFF">
+                                        <br />
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+
+                            <tr bgcolor="#EEEDF2">
+                              <td
+                                style="background-color: #eeedf2;"
+                                bgcolor="#EEEDF2"
+                              >
+                                <table
+                                  style="
+                                    border-collapse: collapse;
+                                    border-spacing: 0;
+                                    border: 0;
+                                    padding: 0;
+                                    width: 100%;
+                                  "
+                                  align="center"
+                                >
+                                  <tbody>
+                                    <tr bgcolor="#EEEDF2">
+                                      <td
+                                        width="30"
+                                        bgcolor="#EEEDF2"
+                                        align="center"
+                                      >
+                                        <br />
+                                      </td>
+                                      <td
+                                        style="
+                                          text-align: center;
+                                          background-color: #eeedf2;
+                                        "
+                                        align="center"
+                                      >
+                                        <br />
+                                        <table
+                                          style="
+                                            border-collapse: collapse;
+                                            border-spacing: 0;
+                                            border: 0;
+                                            padding: 0;
+                                            width: 100%;
+                                            color: #1e0a3c;
+                                          "
+                                          cellspacing="0"
+                                          cellpadding="0"
+                                          bgcolor="#EEEDF2"
+                                          align="center"
+                                        >
+                                          <tbody>
+                                            <tr bgcolor="#EEEDF2">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: center;
+                                                "
+                                                align="center"
+                                                bgcolor="#EEEDF2"
+                                                width="100%"
+                                                height=""
+                                              >
+                                                <div
+                                                  style="
+                                                    width: 100px;
+                                                    height: auto;
+                                                    margin: 0 auto;
+                                                    text-align: center;
+                                                    margin-bottom: 5px;
+                                                  "
+                                                >
+                                                  <img
+                                                    src="https://res.cloudinary.com/mytestlogo/image/upload/v1576044414/bitpod-eventynedi.bitpod.io-logo.png"
+                                                    title=""
+                                                    alt="bitpod"
+                                                    width="90"
+                                                    height=""
+                                                    class="ban-img"
+                                                  />
+                                                </div>
+                                              </td>
+                                            </tr>
+
+                                            <tr bgcolor="#EEEDF2">
+                                              <td
+                                                style="
+                                                  padding: 0;
+                                                  text-align: center;
+                                                "
+                                                align="center"
+                                                bgcolor="#EEEDF2"
+                                                width="100%"
+                                                height="24"
+                                              >
+                                                <span
+                                                  style="
+                                                    font-weight: normal;
+                                                    margin: 4px 0;
+                                                    font-size: 12px;
+                                                    line-height: 18px;
+                                                    font-family: 'Roboto',
+                                                      'Helvetica Neue',
+                                                      Helvetica, Arial,
+                                                      sans-serif;
+                                                    color: #4b4d63;
+                                                    font-weight: normal;
+                                                  "
+                                                >
+                                                  Copyright © 2020 bitpod. All
+                                                  rights reserved.
+                                                </span>
+                                              </td>
+                                            </tr>
+                                            <tr>
+                                              <td
+                                                style="
+                                                  line-height: 18px;
+                                                  font-size: 18px;
+                                                  background-color: #eeedf2;
+                                                "
+                                                width="600"
+                                                height="18"
+                                              >
+                                                <br />
+                                              </td>
+                                            </tr>
+                                          </tbody>
+                                        </table>
+                                      </td>
+                                      <td width="30" bgcolor="#EEEDF2">
+                                        <br />
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,7 +6,7 @@
       class="nav-bar greybg"
       :width="280"
     >
-    <div class="d-block d-sm-none my-3">
+      <div class="d-block d-sm-none my-3">
         <v-menu>
           <template v-slot:activator="{ on, attrs }">
             <v-btn
@@ -56,7 +56,8 @@
             </v-list-item>
           </v-list>
         </v-menu>
-      </div><div class="d-block d-sm-none my-3">
+      </div>
+      <div class="d-block d-sm-none my-3">
         <v-menu>
           <template v-slot:activator="{ on, attrs }">
             <v-btn


### PR DESCRIPTION
Fixed:
#1320:when we edit the event from all events view confermation message is not showing on save
#1311:The google meet and zoom warning message should get clear when i select the bitpod virtual meet as a location type
#1306:From send email invite when i try to clear advanced filter then selected contacts are also get cleard (related 1297)
#1297:Not able to select the prior invite second time while sending an email invite from event detail view
#1273:Not getting selected prior invite after editing the draft mail(Reopen)-This was not saving the parentId while creating the draft mail due to which the while editing it was not showing the draft prior invitee















