### PR TITLE
Bug reg type isMutiple checkbox on select not getting updated 

### DIFF
--- a/config/templates/grids/eventRegistrationType-grid/column-allowmultiple.vue
+++ b/config/templates/grids/eventRegistrationType-grid/column-allowmultiple.vue
@@ -42,6 +42,12 @@ export default {
       checkbox: this.item.AllowMultiple,
     }
   },
+  watch: {
+    'item.AllowMultiple': function (newVal) {
+      debugger
+      this.checkbox = newVal
+    },
+  },
   methods: {
     async updateRegistrationType() {
       const url = this.$bitpod.getApiUrl()

--- a/config/templates/grids/eventRegistrationType-grid/column-allowmultiple.vue
+++ b/config/templates/grids/eventRegistrationType-grid/column-allowmultiple.vue
@@ -44,7 +44,6 @@ export default {
   },
   watch: {
     'item.AllowMultiple': function (newVal) {
-      debugger
       this.checkbox = newVal
     },
   },


### PR DESCRIPTION
Fixed:
1323:From edit registration type form if i check or uncheck the allow multiple checkbox then not reflecting to the grid-
On opening the dialog and then saving the form with isMultiple set to true was not getting updated properly. So added a watcher to the object key and updating it on change of the object value



