### PR TITLE
Bug token refresh issue

### DIFF
--- a/config/common/templates/grid/error.vue
+++ b/config/common/templates/grid/error.vue
@@ -47,7 +47,7 @@ function getGQLAPIErrorMsg(err) {
 }
 
 function getAPIErrorMessage(statusCode, msg) {
-  let userErrorMsg = 'Something went wrong'
+  let userErrorMsg = ''
   switch (statusCode) {
     case 401:
       if (msg === 'jwt expired')

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -346,6 +346,7 @@ export default {
         fetchPolicy: 'no-cache',
       },
     },
+    errorHandler: '~/plugins/apollo-error-handler.js',
   },
   serverMiddleware: ['~/api/index.js', '~/server-middleware/no-cache'],
   auth: {

--- a/plugins/apollo-error-handler.js
+++ b/plugins/apollo-error-handler.js
@@ -30,8 +30,8 @@ export default async (
           expires: 7,
         })
         console.debug('redirecting --->', newToken)
-        nuxtContext.redirect(301, `/apps/event/eventboard`)
       }
     }
+    nuxtContext.redirect(301, `/apps/event/eventboard`)
   }
 }

--- a/plugins/apollo-error-handler.js
+++ b/plugins/apollo-error-handler.js
@@ -1,4 +1,3 @@
-// import nuxtconfig from '~/nuxt.config'
 export default async (
   { graphQLErrors, networkError, operation, forward },
   nuxtContext

--- a/plugins/apollo-error-handler.js
+++ b/plugins/apollo-error-handler.js
@@ -2,24 +2,35 @@ export default async (
   { graphQLErrors, networkError, operation, forward },
   nuxtContext
 ) => {
+  console.debug('nuxtContext--->', nuxtContext)
   let token = ''
   if (nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']) {
     token = nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']
+    console.debug('token1--->', token)
   } else {
     token = nuxtContext.$auth.$storage.getCookies()['auth._token.google']
+    console.debug('token2--->', token)
   }
   const strategy = nuxtContext.$auth.$storage.getCookies()['auth.strategy']
+  console.debug('strategy--->', strategy)
   if (strategy === 'bitpod' || strategy === 'google') {
+    console.debug(
+      'apollo---->',
+      nuxtContext.$auth.$storage.getCookies()['apollo-token']
+    )
     if (
       token.split(' ')[1] !==
       nuxtContext.$auth.$storage.getCookies()['apollo-token']
     ) {
-      let newToken = this.$auth.strategy.token.get()
+      let newToken = nuxtContext.$auth.strategy.token.get()
+      console.debug('newToken--->', newToken)
       if (newToken) {
         newToken = newToken.split(' ')[1]
         await nuxtContext.$apolloHelpers.onLogin(newToken, undefined, {
           expires: 7,
         })
+        console.debug('redirecting --->', newToken)
+        nuxtContext.redirect(301, `/apps/event/eventboard`)
       }
     }
   }

--- a/plugins/apollo-error-handler.js
+++ b/plugins/apollo-error-handler.js
@@ -1,12 +1,8 @@
-// const get = (o, p) => p.reduce((xs, x) => (xs && xs[x] ? xs[x] : null), o)
 export default async (
   { graphQLErrors, networkError, operation, forward },
   nuxtContext
 ) => {
-  // const msg = getGQLAPIErrorMsg(graphQLErrors)
-  // console.log('message', msg)
-  if (networkError && networkError.length > 0 && networkError.includes('401')) {
-    debugger
+  if (networkError && JSON.stringify(networkError).includes('401')) {
     let token = ''
     if (nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']) {
       token = nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']
@@ -40,40 +36,3 @@ export default async (
     }
   }
 }
-
-// function onError(error) {
-//   debugger
-//   console.log('err', error)
-// }
-// function getGQLAPIErrorMsg(err) {
-//   debugger
-//   const networkError = get(err, ['networkError'])
-//   let statusCode =
-//     get(networkError, ['result', 'error', 'statusCode']) ||
-//     get(networkError, ['statusCode'])
-//   let msg =
-//     get(networkError, ['result', 'error', 'message']) ||
-//     get(networkError, ['message'])
-//   const graphQLErrors = get(err, ['graphQLErrors'])
-//   if (graphQLErrors && graphQLErrors.length > 0) {
-//     msg = get(graphQLErrors, ['0', 'message'])
-//     switch (msg) {
-//       case 'Access denied':
-//         statusCode = 401
-//         break
-//     }
-//   }
-//   return getAPIErrorMessage(statusCode, msg)
-// }
-
-// function getAPIErrorMessage(statusCode, msg) {
-//   debugger
-//   let userErrorMsg = ' '
-//   switch (statusCode) {
-//     case 401:
-//       if (msg === 'jwt expired')
-//         userErrorMsg = 'Session Expired. please refresh page.'
-//       break
-//   }
-//   return userErrorMsg
-// }

--- a/plugins/apollo-error-handler.js
+++ b/plugins/apollo-error-handler.js
@@ -3,43 +3,25 @@ export default async (
   { graphQLErrors, networkError, operation, forward },
   nuxtContext
 ) => {
-  debugger
   let token = ''
   if (nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']) {
     token = nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']
   } else {
     token = nuxtContext.$auth.$storage.getCookies()['auth._token.google']
   }
-  console.log('tokenr', token)
   const strategy = nuxtContext.$auth.$storage.getCookies()['auth.strategy']
   if (strategy === 'bitpod' || strategy === 'google') {
-    console.log('strategy matched===>')
-    console.log(
-      'apollow-tojken',
-      nuxtContext.$auth.$storage.getCookies()['apollo-token']
-    )
     if (
       token.split(' ')[1] !==
       nuxtContext.$auth.$storage.getCookies()['apollo-token']
     ) {
-      console.log('not similar setting new token ====>')
       let newToken = this.$auth.strategy.token.get()
-      console.log('not similar setting new token ====>', newToken)
       if (newToken) {
         newToken = newToken.split(' ')[1]
-
         await nuxtContext.$apolloHelpers.onLogin(newToken, undefined, {
           expires: 7,
         })
-        // nuxtContext.redirect(302, `${nuxtconfig.auth.redirect.home}`)
-        console.log(
-          'after setting apollow-tojken',
-          nuxtContext.$auth.$storage.getCookies()['apollo-token']
-        )
       }
     }
   }
-  debugger
-  console.log('Global error handler')
-  console.log(graphQLErrors, networkError, operation, forward)
 }

--- a/plugins/apollo-error-handler.js
+++ b/plugins/apollo-error-handler.js
@@ -6,30 +6,21 @@ export default async (
     let token = ''
     if (nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']) {
       token = nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']
-      console.debug('token1--->', token)
     } else {
       token = nuxtContext.$auth.$storage.getCookies()['auth._token.google']
-      console.debug('token2--->', token)
     }
     const strategy = nuxtContext.$auth.$storage.getCookies()['auth.strategy']
-    console.debug('strategy--->', strategy)
     if (strategy === 'bitpod' || strategy === 'google') {
-      console.debug(
-        'apollo---->',
-        nuxtContext.$auth.$storage.getCookies()['apollo-token']
-      )
       if (
         token.split(' ')[1] !==
         nuxtContext.$auth.$storage.getCookies()['apollo-token']
       ) {
         let newToken = nuxtContext.$auth.strategy.token.get()
-        console.debug('newToken--->', newToken)
         if (newToken) {
           newToken = newToken.split(' ')[1]
           await nuxtContext.$apolloHelpers.onLogin(newToken, undefined, {
             expires: 7,
           })
-          console.debug('redirecting --->', newToken)
         }
       }
       nuxtContext.redirect(301, `/apps/event/eventboard`)

--- a/plugins/apollo-error-handler.js
+++ b/plugins/apollo-error-handler.js
@@ -1,0 +1,45 @@
+// import nuxtconfig from '~/nuxt.config'
+export default async (
+  { graphQLErrors, networkError, operation, forward },
+  nuxtContext
+) => {
+  debugger
+  let token = ''
+  if (nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']) {
+    token = nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']
+  } else {
+    token = nuxtContext.$auth.$storage.getCookies()['auth._token.google']
+  }
+  console.log('tokenr', token)
+  const strategy = nuxtContext.$auth.$storage.getCookies()['auth.strategy']
+  if (strategy === 'bitpod' || strategy === 'google') {
+    console.log('strategy matched===>')
+    console.log(
+      'apollow-tojken',
+      nuxtContext.$auth.$storage.getCookies()['apollo-token']
+    )
+    if (
+      token.split(' ')[1] !==
+      nuxtContext.$auth.$storage.getCookies()['apollo-token']
+    ) {
+      console.log('not similar setting new token ====>')
+      let newToken = this.$auth.strategy.token.get()
+      console.log('not similar setting new token ====>', newToken)
+      if (newToken) {
+        newToken = newToken.split(' ')[1]
+
+        await nuxtContext.$apolloHelpers.onLogin(newToken, undefined, {
+          expires: 7,
+        })
+        // nuxtContext.redirect(302, `${nuxtconfig.auth.redirect.home}`)
+        console.log(
+          'after setting apollow-tojken',
+          nuxtContext.$auth.$storage.getCookies()['apollo-token']
+        )
+      }
+    }
+  }
+  debugger
+  console.log('Global error handler')
+  console.log(graphQLErrors, networkError, operation, forward)
+}

--- a/plugins/apollo-error-handler.js
+++ b/plugins/apollo-error-handler.js
@@ -1,37 +1,79 @@
+// const get = (o, p) => p.reduce((xs, x) => (xs && xs[x] ? xs[x] : null), o)
 export default async (
   { graphQLErrors, networkError, operation, forward },
   nuxtContext
 ) => {
-  console.debug('nuxtContext--->', nuxtContext)
-  let token = ''
-  if (nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']) {
-    token = nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']
-    console.debug('token1--->', token)
-  } else {
-    token = nuxtContext.$auth.$storage.getCookies()['auth._token.google']
-    console.debug('token2--->', token)
-  }
-  const strategy = nuxtContext.$auth.$storage.getCookies()['auth.strategy']
-  console.debug('strategy--->', strategy)
-  if (strategy === 'bitpod' || strategy === 'google') {
-    console.debug(
-      'apollo---->',
-      nuxtContext.$auth.$storage.getCookies()['apollo-token']
-    )
-    if (
-      token.split(' ')[1] !==
-      nuxtContext.$auth.$storage.getCookies()['apollo-token']
-    ) {
-      let newToken = nuxtContext.$auth.strategy.token.get()
-      console.debug('newToken--->', newToken)
-      if (newToken) {
-        newToken = newToken.split(' ')[1]
-        await nuxtContext.$apolloHelpers.onLogin(newToken, undefined, {
-          expires: 7,
-        })
-        console.debug('redirecting --->', newToken)
-      }
+  // const msg = getGQLAPIErrorMsg(graphQLErrors)
+  // console.log('message', msg)
+  if (networkError && networkError.length > 0 && networkError.includes('401')) {
+    debugger
+    let token = ''
+    if (nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']) {
+      token = nuxtContext.$auth.$storage.getCookies()['auth._token.bitpod']
+      console.debug('token1--->', token)
+    } else {
+      token = nuxtContext.$auth.$storage.getCookies()['auth._token.google']
+      console.debug('token2--->', token)
     }
-    nuxtContext.redirect(301, `/apps/event/eventboard`)
+    const strategy = nuxtContext.$auth.$storage.getCookies()['auth.strategy']
+    console.debug('strategy--->', strategy)
+    if (strategy === 'bitpod' || strategy === 'google') {
+      console.debug(
+        'apollo---->',
+        nuxtContext.$auth.$storage.getCookies()['apollo-token']
+      )
+      if (
+        token.split(' ')[1] !==
+        nuxtContext.$auth.$storage.getCookies()['apollo-token']
+      ) {
+        let newToken = nuxtContext.$auth.strategy.token.get()
+        console.debug('newToken--->', newToken)
+        if (newToken) {
+          newToken = newToken.split(' ')[1]
+          await nuxtContext.$apolloHelpers.onLogin(newToken, undefined, {
+            expires: 7,
+          })
+          console.debug('redirecting --->', newToken)
+        }
+      }
+      nuxtContext.redirect(301, `/apps/event/eventboard`)
+    }
   }
 }
+
+// function onError(error) {
+//   debugger
+//   console.log('err', error)
+// }
+// function getGQLAPIErrorMsg(err) {
+//   debugger
+//   const networkError = get(err, ['networkError'])
+//   let statusCode =
+//     get(networkError, ['result', 'error', 'statusCode']) ||
+//     get(networkError, ['statusCode'])
+//   let msg =
+//     get(networkError, ['result', 'error', 'message']) ||
+//     get(networkError, ['message'])
+//   const graphQLErrors = get(err, ['graphQLErrors'])
+//   if (graphQLErrors && graphQLErrors.length > 0) {
+//     msg = get(graphQLErrors, ['0', 'message'])
+//     switch (msg) {
+//       case 'Access denied':
+//         statusCode = 401
+//         break
+//     }
+//   }
+//   return getAPIErrorMessage(statusCode, msg)
+// }
+
+// function getAPIErrorMessage(statusCode, msg) {
+//   debugger
+//   let userErrorMsg = ' '
+//   switch (statusCode) {
+//     case 401:
+//       if (msg === 'jwt expired')
+//         userErrorMsg = 'Session Expired. please refresh page.'
+//       break
+//   }
+//   return userErrorMsg
+// }

--- a/utility/index.js
+++ b/utility/index.js
@@ -313,7 +313,7 @@ export const configLoaderMixin = {
       contents: null,
     }
   },
-  created() {
+  async created() {
     const strategy = this.$auth.$storage.getCookies()['auth.strategy']
     if (this.$auth.$storage.getCookies()['auth._token.bitpod']) {
       this.token = this.$auth.$storage.getCookies()['auth._token.bitpod']

--- a/utility/index.js
+++ b/utility/index.js
@@ -313,26 +313,26 @@ export const configLoaderMixin = {
       contents: null,
     }
   },
-  async created() {
-    console.debug('access token received from the cookie', this.token)
-    const strategy = this.$auth.$storage.getCookies()['auth.strategy']
-    if (this.$auth.$storage.getCookies()['auth._token.bitpod']) {
-      this.token = this.$auth.$storage.getCookies()['auth._token.bitpod']
-    } else {
-      this.token = this.$auth.$storage.getCookies()['auth._token.google']
-    }
-    if (strategy === 'bitpod' || strategy === 'google') {
-      if (
-        this.token.split(' ')[1] !==
-        this.$auth.$storage.getCookies()['apollo-token']
-      ) {
-        let token = this.$auth.strategy.token.get()
-        if (token) {
-          token = token.split(' ')[1]
-        }
-        await this.$apolloHelpers.onLogin(token, undefined, { expires: 7 })
-      }
-    }
+  created() {
+    // console.debug('access token received from the cookie', this.token)
+    // const strategy = this.$auth.$storage.getCookies()['auth.strategy']
+    // if (this.$auth.$storage.getCookies()['auth._token.bitpod']) {
+    //   this.token = this.$auth.$storage.getCookies()['auth._token.bitpod']
+    // } else {
+    //   this.token = this.$auth.$storage.getCookies()['auth._token.google']
+    // }
+    // if (strategy === 'bitpod' || strategy === 'google') {
+    //   if (
+    //     this.token.split(' ')[1] !==
+    //     this.$auth.$storage.getCookies()['apollo-token']
+    //   ) {
+    //     let token = this.$auth.strategy.token.get()
+    //     if (token) {
+    //       token = token.split(' ')[1]
+    //     }
+    //     await this.$apolloHelpers.onLogin(token, undefined, { expires: 7 })
+    //   }
+    // }
   },
   async mounted() {
     const contentFactory = await import(

--- a/utility/index.js
+++ b/utility/index.js
@@ -309,30 +309,8 @@ export const configLoaderMixin = {
   },
   data() {
     return {
-      token: '',
       contents: null,
     }
-  },
-  created() {
-    // console.debug('access token received from the cookie', this.token)
-    // const strategy = this.$auth.$storage.getCookies()['auth.strategy']
-    // if (this.$auth.$storage.getCookies()['auth._token.bitpod']) {
-    //   this.token = this.$auth.$storage.getCookies()['auth._token.bitpod']
-    // } else {
-    //   this.token = this.$auth.$storage.getCookies()['auth._token.google']
-    // }
-    // if (strategy === 'bitpod' || strategy === 'google') {
-    //   if (
-    //     this.token.split(' ')[1] !==
-    //     this.$auth.$storage.getCookies()['apollo-token']
-    //   ) {
-    //     let token = this.$auth.strategy.token.get()
-    //     if (token) {
-    //       token = token.split(' ')[1]
-    //     }
-    //     await this.$apolloHelpers.onLogin(token, undefined, { expires: 7 })
-    //   }
-    // }
   },
   async mounted() {
     const contentFactory = await import(

--- a/utility/index.js
+++ b/utility/index.js
@@ -309,14 +309,19 @@ export const configLoaderMixin = {
   },
   data() {
     return {
-      token: this.$auth.$storage.getCookies()['auth._token.bitpod'],
+      token: '',
       contents: null,
     }
   },
   async created() {
     console.debug('access token received from the cookie', this.token)
     const strategy = this.$auth.$storage.getCookies()['auth.strategy']
-    if (strategy === 'bitpod') {
+    if (this.$auth.$storage.getCookies()['auth._token.bitpod']) {
+      this.token = this.$auth.$storage.getCookies()['auth._token.bitpod']
+    } else {
+      this.token = this.$auth.$storage.getCookies()['auth._token.google']
+    }
+    if (strategy === 'bitpod' || strategy === 'google') {
       if (
         this.token.split(' ')[1] !==
         this.$auth.$storage.getCookies()['apollo-token']

--- a/utility/index.js
+++ b/utility/index.js
@@ -309,7 +309,28 @@ export const configLoaderMixin = {
   },
   data() {
     return {
+      token: '',
       contents: null,
+    }
+  },
+  created() {
+    const strategy = this.$auth.$storage.getCookies()['auth.strategy']
+    if (this.$auth.$storage.getCookies()['auth._token.bitpod']) {
+      this.token = this.$auth.$storage.getCookies()['auth._token.bitpod']
+    } else {
+      this.token = this.$auth.$storage.getCookies()['auth._token.google']
+    }
+    if (strategy === 'bitpod' || strategy === 'google') {
+      if (
+        this.token.split(' ')[1] !==
+        this.$auth.$storage.getCookies()['apollo-token']
+      ) {
+        let token = this.$auth.strategy.token.get()
+        if (token) {
+          token = token.split(' ')[1]
+        }
+        await this.$apolloHelpers.onLogin(token, undefined, { expires: 7 })
+      }
     }
   },
   async mounted() {


### PR DESCRIPTION
Fixed issue of google login and also if you keep the screen in standby mode the gql query was getting failed which led to the msg "Session expired".
Have gone through the docs:- https://www.npmjs.com/package/@nuxtjs/apollo. Found out the various options through we could inject the error and handle it.Found a option in it using error handler and making a plugin which is handling this bypass of error if there is any in gql there i am setting the token now with new token.