### PR TITLE
Fixed issue of sendEmail invite not able to select mutiple prior invitee

### DIFF
--- a/components/common/grid/index.vue
+++ b/components/common/grid/index.vue
@@ -841,7 +841,6 @@ export default {
     },
   },
   mounted() {
-    debugger
     setTimeout(() => {
       this.selectedItems = []
     }, 2000)

--- a/config/apps/event/content/contacts.js
+++ b/config/apps/event/content/contacts.js
@@ -905,7 +905,7 @@ export default {
         hideDefaultFooter: false,
         showExpand: false,
         singleExpand: false,
-        showSelect: false,
+        showSelect: true,
         hideFilter: false,
         hideSearch: true,
       },
@@ -962,6 +962,9 @@ export default {
             hidden: true,
           },
           edit: {
+            hidden: true,
+          },
+          delete: {
             hidden: true,
           },
           exportCsv: {

--- a/config/apps/event/content/event.js
+++ b/config/apps/event/content/event.js
@@ -5426,7 +5426,7 @@ export default {
         hideDefaultFooter: false,
         showExpand: false,
         singleExpand: false,
-        showSelect: false,
+        showSelect: true,
         hideFilter: false,
         hideSearch: true,
       },
@@ -5483,6 +5483,9 @@ export default {
             hidden: true,
           },
           edit: {
+            hidden: true,
+          },
+          delete: {
             hidden: true,
           },
           exportCsv: {

--- a/config/templates/grids/eventInvites-grid/actions/grid/sendEventInvite.vue
+++ b/config/templates/grids/eventInvites-grid/actions/grid/sendEventInvite.vue
@@ -912,10 +912,19 @@ export default {
   },
   computed: {
     filter() {
-      return {
-        where: {
-          EventId: this.draftData.EventId,
-        },
+      if (this.draftData.EventId) {
+        return {
+          where: {
+            EventId: this.draftData.EventId,
+            Type: 'Mass Email',
+          },
+        }
+      } else {
+        return {
+          where: {
+            and: [{ Type: 'Mass Email' }],
+          },
+        }
       }
     },
     dropdownOptions() {
@@ -998,6 +1007,9 @@ export default {
   },
   methods: {
     onResetPriorInvitee() {
+      if (this.editDraft) {
+        this.priorSelectedData = {}
+      }
       this.registrationRadio = ''
       this.openRadio = ''
       this.priorInvite = {}
@@ -1156,7 +1168,7 @@ export default {
       const postData = {
         ContactId: this.selectedList.map((i) => i.id),
         DueDate: null,
-        EventId: this.$route.params.id,
+        EventId: !this.editDraft ? this.$route.params.id : null,
         IncludeRegister: true,
         Name: '',
         Owner: this.sender,
@@ -1182,7 +1194,7 @@ export default {
         postData.Status = type
       }
       if (type === 'Draft') {
-        postData.ParentId = this.priorInvite.id
+        postData.ParentId = this.priorInvite.id ? this.priorInvite.id : ''
         postData.Status = type
       }
       if (this.selectAll) {

--- a/pages/apps/_app/event/invite/_id/index.vue
+++ b/pages/apps/_app/event/invite/_id/index.vue
@@ -448,6 +448,7 @@ export default {
     async getPrior(id) {
       if (!id) {
         this.prevReady = true
+        this.priorData = {}
       } else {
         const prev = await this.$axios.$get(
           `${this.$bitpod.getApiUrl()}CRMACTIVITIES/${id}`
@@ -475,6 +476,7 @@ export default {
           },
         }
       },
+      fetchPolicy: 'no-cache',
       update(data) {
         const invites = formatGQLResult(data, 'CRMActivity')
         if (invites && invites.length) {


### PR DESCRIPTION
Fixed:
1339:When I edit the draft email invite from community tab then getting only one prior invitation
1329:When the user edit the draft email and try to select prior invite then getting calendar invitation and registration mails
1328:When I try to edit the draft email invite second time and save then it get removed from invitation history